### PR TITLE
JCRVLT-163 - Avoid compressing incompressible binaries

### DIFF
--- a/vault-core/src/main/java/org/apache/jackrabbit/vault/fs/impl/io/CompressionUtil.java
+++ b/vault-core/src/main/java/org/apache/jackrabbit/vault/fs/impl/io/CompressionUtil.java
@@ -1,0 +1,188 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.jackrabbit.vault.fs.impl.io;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+import javax.annotation.Nonnull;
+import javax.jcr.RepositoryException;
+
+import org.apache.commons.io.IOUtils;
+import org.apache.jackrabbit.vault.fs.api.Artifact;
+import org.apache.jackrabbit.vault.fs.api.SerializationType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * {@code CompressionUtil} is a utility class that allows to evaluate
+ * the compressibility of artifacts.
+ */
+public final class CompressionUtil {
+
+    /**
+     * default logger
+     */
+    private static final Logger log = LoggerFactory.getLogger(CompressionUtil.class);
+
+    /**
+     * Minimum length to run the auto-detection algorithm in Byte.
+     */
+    private static final long MIN_AUTO_DETECTION_LENGTH = 115 * 1024;
+
+    /**
+     * Length of the sample (in byte) peeked from the artifact for running the auto-detection algorithm.
+     */
+    private static final int SAMPLE_LENGTH = 256;
+
+    // TODO extend the MIME type lists
+
+    /**
+     * List of well known mime types identifying to compressed formats.
+     */
+    private static final Set<String> INCOMPRESSIBLE_MIME_TYPES = new HashSet<String>(Arrays.asList(
+            "image/gif",
+            "image/jpeg",
+            "image/png",
+            "multipart/x-gzip",
+            "video/mp4",
+            "application/gzip",
+            "application/java-archive",
+            "application/mp4",
+            "application/x-7z-compressed",
+            "application/x-compressed",
+            "application/x-gzip",
+            "application/x-rar-compressed",
+            "application/zip",
+            "application/zlib",
+            "audio/mpeg"
+    ));
+
+    /**
+     * List of well known mime types identifying to non compressed formats.
+     */
+    private static final Set<String> COMPRESSIBLE_MIME_TYPES = new HashSet<String>(Arrays.asList(
+            "application/xml",
+            "application/java",
+            "application/json",
+            "application/javascript",
+            "application/ecmascript"
+    ));
+
+    /**
+     * Estimates if the provided artifact is compressible.
+     *
+     * @param artifact the artifact to be tested for compressibility
+     * @return A negative integer, a positive integer or zero depending on whether the artifact
+     *         is estimated to be incompressible, compressible or if the estimate did not run.
+     */
+    public static int isCompressible(@Nonnull Artifact artifact) {
+
+        if (SerializationType.GENERIC == artifact.getSerializationType()) {
+
+            /*
+             * Test for known content types
+             */
+            String contentType = artifact.getContentType();
+            if (contentType != null) {
+                contentType = contentType.toLowerCase();
+                if (isCompressibleContentType(contentType)) {
+                    return 1;
+                }
+                if (isIncompressibleContentType(contentType)) {
+                    return -1;
+                }
+            }
+
+            /*
+             * Apply compressibility prediction heuristic on a sample of the artifact
+             *
+             * The heuristic is tested only if the expected cost of running the heuristic
+             * is smaller than 3% of the expected cost of compressing the artifact, such
+             * that the extra cost is reasonable in the worst case.
+             *
+             *
+             * The compression throughput is assumed to be 80 MB/s or less.
+             * The cost of peeking a sample and running the heuristic is expected to be 150μs or less.
+             *
+             * The artifact size threshold is thus set to 115KB.
+             *
+             * A better improved implementation may measure those values and self tune for a
+             * specific runtime.
+             */
+            long contentLength = artifact.getContentLength();
+            if (contentLength > MIN_AUTO_DETECTION_LENGTH) {
+                return seemsCompressible(artifact);
+            }
+        }
+        return 0;
+    }
+
+    static boolean isCompressibleContentType(@Nonnull String mimeType) {
+        return  mimeType.startsWith("text/") || COMPRESSIBLE_MIME_TYPES.contains(mimeType);
+    }
+
+    static boolean isIncompressibleContentType(@Nonnull String mimeType) {
+        return INCOMPRESSIBLE_MIME_TYPES.contains(mimeType);
+    }
+
+    static int seemsCompressible(@Nonnull Artifact artifact) {
+        InputStream stream = null;
+        try {
+            stream = artifact.getInputStream();
+            byte[] sample = IOUtils.toByteArray(stream, SAMPLE_LENGTH);
+            return isCompressible(sample, SAMPLE_LENGTH) ? 1 : -1;
+        } catch (RepositoryException | IOException e) {
+            log.warn(e.getMessage(), e);
+        } finally {
+            IOUtils.closeQuietly(stream);
+        }
+        return 0;
+    }
+
+    /**
+     * This algorithm estimates the entropy of the high nibbles.
+     *
+     * Credits to Thomas Mueller's for this solution, shared on StackOverflow at
+     * <a href="http://bit.ly/2mKsp0v">How To Efficiently Predict If Data Is Compressible</a>
+     *
+     * @param data the data to be tested for compressibility
+     * @param len the length of the data to be tested
+     * @return {@code true} if the data sample is compressible,
+     *         {@code false} otherwise.
+     */
+    static boolean isCompressible(byte[] data, int len) {
+        // the number of bytes with
+        // high nibble 0, 1,.., 15
+        int[] sum = new int[16];
+        for (int i = 0; i < len; i++) {
+            int x = (data[i] & 255) >> 4;
+            sum[x]++;
+        }
+        // see wikipedia to understand this formula :-)
+        int r = 0;
+        for (int x : sum) {
+            long v = ((long) x << 32) / len;
+            r += 63 - Long.numberOfLeadingZeros(v + 1);
+        }
+        return len * r < 438 * len;
+    }
+
+}

--- a/vault-core/src/main/java/org/apache/jackrabbit/vault/fs/io/package-info.java
+++ b/vault-core/src/main/java/org/apache/jackrabbit/vault/fs/io/package-info.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-@Version("2.4.0")
+@Version("2.5.0")
 package org.apache.jackrabbit.vault.fs.io;
 
 import aQute.bnd.annotation.Version;

--- a/vault-core/src/main/java/org/apache/jackrabbit/vault/packaging/ExportOptions.java
+++ b/vault-core/src/main/java/org/apache/jackrabbit/vault/packaging/ExportOptions.java
@@ -35,6 +35,8 @@ public class ExportOptions {
 
     private String mountPath;
 
+    private int compressionLevel = -1;
+
     /**
      * Returns the progress tracker listener.
      * @return the progress tracker listener.
@@ -121,5 +123,21 @@ public class ExportOptions {
      */
     public void setMountPath(String mountPath) {
         this.mountPath = mountPath;
+    }
+
+    /**
+     * Defines the compression level for the export.
+     * @param compressionLevel the compression level
+     */
+    public void setCompressionLevel(int compressionLevel) {
+        this.compressionLevel = compressionLevel;
+    }
+
+    /**
+     * Returns the compression level
+     * @return the compression level
+     */
+    public int getCompressionLevel() {
+        return compressionLevel;
     }
 }

--- a/vault-core/src/main/java/org/apache/jackrabbit/vault/packaging/impl/PackageManagerImpl.java
+++ b/vault-core/src/main/java/org/apache/jackrabbit/vault/packaging/impl/PackageManagerImpl.java
@@ -133,7 +133,7 @@ public class PackageManagerImpl implements PackageManager {
         }
 
         VaultFileSystem jcrfs = Mounter.mount(config, metaInf.getFilter(), addr, opts.getRootPath(), s);
-        JarExporter exporter = new JarExporter(out);
+        JarExporter exporter = new JarExporter(out, opts.getCompressionLevel());
         exporter.setProperties(metaInf.getProperties());
         if (opts.getListener() != null) {
             exporter.setVerbose(opts.getListener());
@@ -185,7 +185,7 @@ public class PackageManagerImpl implements PackageManager {
         if (metaInf == null) {
             metaInf = new DefaultMetaInf();
         }
-        JarExporter exporter = new JarExporter(out);
+        JarExporter exporter = new JarExporter(out, opts.getCompressionLevel());
         exporter.open();
         exporter.setProperties(metaInf.getProperties());
         ProgressTracker tracker = null;

--- a/vault-core/src/test/java/org/apache/jackrabbit/vault/fs/impl/io/CompressionUtilTest.java
+++ b/vault-core/src/test/java/org/apache/jackrabbit/vault/fs/impl/io/CompressionUtilTest.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.jackrabbit.vault.fs.impl.io;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Arrays;
+import java.util.Random;
+
+import javax.jcr.RepositoryException;
+
+import org.apache.jackrabbit.vault.fs.api.Artifact;
+import org.apache.jackrabbit.vault.fs.api.SerializationType;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import static junit.framework.Assert.assertTrue;
+import static junit.framework.Assert.assertFalse;
+import static org.apache.jackrabbit.vault.fs.impl.io.CompressionUtil.*;
+
+public class CompressionUtilTest {
+
+    private static final Random RAND = new Random();
+
+    private static final String COMPRESSIBLE_MIME_TYPE = "text/plain";
+
+    private static final String INCOMPRESSIBLE_MIME_TYPE = "image/png";
+
+    private static final String UNKNOWN_MIME_TYPE = "unkown/unknown";
+
+    @Test
+    public void testCompressibilityByMimeType() {
+        assertTrue(isIncompressibleContentType(INCOMPRESSIBLE_MIME_TYPE));
+        assertFalse(isIncompressibleContentType(UNKNOWN_MIME_TYPE));
+        assertFalse(isIncompressibleContentType(COMPRESSIBLE_MIME_TYPE));
+        assertTrue(isCompressibleContentType(COMPRESSIBLE_MIME_TYPE));
+        assertFalse(isCompressibleContentType(UNKNOWN_MIME_TYPE));
+    }
+
+    @Test
+    public void testCompressibilityEstimation()
+            throws IOException, RepositoryException {
+        assertTrue(seemsCompressible(newArtifact(incompressibleData(5*1024), null)) < 0);
+        assertTrue(seemsCompressible(newArtifact(compressibleData(5*1024), null)) > 0);
+    }
+
+    @Test
+    public void testCompressibility()
+            throws IOException, RepositoryException {
+        byte[] comp256KB = compressibleData(256*1024);
+        byte[] incomp256KB = incompressibleData(256*1024);
+        assertTrue(isCompressible(newArtifact(comp256KB, COMPRESSIBLE_MIME_TYPE)) > 0);
+        assertTrue(isCompressible(newArtifact(comp256KB, UNKNOWN_MIME_TYPE)) > 0);
+        assertTrue(isCompressible(newArtifact(comp256KB, null)) > 0);
+        assertTrue(isCompressible(newArtifact(new byte[10], null)) == 0);
+        assertTrue(isCompressible(newArtifact(incomp256KB, UNKNOWN_MIME_TYPE)) < 0);
+        assertTrue(isCompressible(newArtifact(incomp256KB, INCOMPRESSIBLE_MIME_TYPE)) < 0);
+    }
+
+    private Artifact newArtifact(byte[] data, String contentType)
+            throws IOException, RepositoryException {
+        Artifact artifact = Mockito.mock(Artifact.class);
+        InputStream inputStream = new ByteArrayInputStream(data);
+        Mockito.when(artifact.getInputStream()).thenReturn(inputStream);
+        Mockito.when(artifact.getContentLength()).thenReturn((long) data.length);
+        Mockito.when(artifact.getContentType()).thenReturn(contentType);
+        Mockito.when(artifact.getSerializationType()).thenReturn(SerializationType.GENERIC);
+        return artifact;
+    }
+
+    private byte[] compressibleData(int length) {
+        byte[] data = new byte[length];
+        Arrays.fill(data, (byte)42);
+        return data;
+    }
+
+    private byte[] incompressibleData(int length) {
+        byte[] data = new byte[length];
+        RAND.nextBytes(data);
+        return data;
+    }
+}

--- a/vault-core/src/test/java/org/apache/jackrabbit/vault/packaging/integration/TestCompressionExport.java
+++ b/vault-core/src/test/java/org/apache/jackrabbit/vault/packaging/integration/TestCompressionExport.java
@@ -1,0 +1,229 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.jackrabbit.vault.packaging.integration;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.Arrays;
+import java.util.Properties;
+import java.util.Random;
+import java.util.zip.Deflater;
+
+import javax.jcr.Node;
+import javax.jcr.RepositoryException;
+
+import org.apache.jackrabbit.commons.JcrUtils;
+import org.apache.jackrabbit.vault.fs.api.PathFilterSet;
+import org.apache.jackrabbit.vault.fs.config.DefaultMetaInf;
+import org.apache.jackrabbit.vault.fs.config.DefaultWorkspaceFilter;
+import org.apache.jackrabbit.vault.packaging.ExportOptions;
+import org.apache.jackrabbit.vault.packaging.PackageException;
+import org.apache.jackrabbit.vault.packaging.VaultPackage;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Test cases for custom compression level on export.
+ * This test case requires a long time to run, thus it is disabled by default.
+ */
+@Ignore
+public class TestCompressionExport extends IntegrationTestBase {
+
+    /**
+     * default logger
+     */
+    private static final Logger log = LoggerFactory.getLogger(TestCompressionExport.class);
+
+    private static final Random RAND = new Random();
+
+    private static final String TEST_PARENT_PATH = "/tmp/testCompressionExport";
+
+    private static final String COMPRESSIBLE_MIME_TYPE = "text/plain";
+
+    private static final String INCOMPRESSIBLE_MIME_TYPE = "image/png";
+
+    private static final String UNKNOWN_MIME_TYPE = "unkown/unknown";
+
+    private static final int NB_WARMUP_ITERATIONS = 100;
+
+    private static final int NB_TEST_ITERATIONS = 10000;
+
+    @Before
+    public void setup() throws RepositoryException, PackageException, IOException {
+        JcrUtils.getOrCreateByPath(TEST_PARENT_PATH, "nt:unstructured", admin);
+        admin.save();
+    }
+
+    @After
+    public void after() throws RepositoryException {
+        if (admin.nodeExists(TEST_PARENT_PATH)) {
+            admin.getNode(TEST_PARENT_PATH).remove();
+            admin.save();
+        }
+    }
+
+    @Test
+    public void test100KB_to_120KB() throws RepositoryException, IOException {
+        for (int size = 100 * 1024 ; size < 120 * 1024 ; size += 10 * 1024) {
+            runTestAndAssertGains(size);
+        }
+    }
+
+    @Test
+    public void test1MB() throws RepositoryException, IOException {
+        runTestAndAssertGains(1024 * 1024);
+    }
+
+    @Test
+    public void test10MB() throws RepositoryException, IOException {
+        runTestAndAssertGains(10 * 1024 * 1024);
+    }
+
+    private void runTestAndAssertGains(int size)
+            throws RepositoryException, IOException {
+        compareWithAndWithoutOptimization(storeFile(true, COMPRESSIBLE_MIME_TYPE, size));
+        compareWithAndWithoutOptimization(storeFile(false, INCOMPRESSIBLE_MIME_TYPE, size));
+        compareWithAndWithoutOptimization(storeFile(true, UNKNOWN_MIME_TYPE, size));
+        compareWithAndWithoutOptimization(storeFile(false, UNKNOWN_MIME_TYPE, size));
+    }
+
+    private void compareWithAndWithoutOptimization(String path)
+            throws IOException, RepositoryException {
+        SizeDuration noOptimization = measureExportDuration(path, Deflater.DEFAULT_COMPRESSION);
+        SizeDuration withOptimization = measureExportDuration(path, 6); // level 6 is used for the DEFAULT_COMPRESSION strategy
+        float durationGain = (noOptimization.duration - withOptimization.duration) / (float) noOptimization.duration;
+        float sizeGain = (noOptimization.size - withOptimization.size) / (float) noOptimization.size;
+        log.info("Path {} duration gain: {}, size gain: {}", new Object[]{path, durationGain, sizeGain});
+        // assert the optimization does not imply a decrease of throughput larger than 3%
+        assertTrue(noOptimization.duration * 1.03f > withOptimization.duration);
+    }
+
+    private SizeDuration measureExportDuration(String nodePath, int level)
+            throws IOException, RepositoryException {
+        ExportOptions opts = buildExportOptions(nodePath, level);
+        log.info("Warmup for path {} and compression level {}",
+                new Object[]{nodePath, level});
+        exportMultipleTimes(opts, NB_WARMUP_ITERATIONS);
+        log.info("Run for path {} and compression level {}",
+                new Object[]{nodePath, level});
+        long start = System.nanoTime();
+        long size = exportMultipleTimes(opts, NB_TEST_ITERATIONS);
+        long stop = System.nanoTime();
+        SizeDuration sd = new SizeDuration(size, stop - start);
+        float rate = (sd.size / (float)sd.duration * 1000);
+        log.info("Ran for path {} and compression level {} in {} ns produced {} B ({} MB/s)",
+                new Object[]{nodePath, level, sd.duration, sd.size, rate});
+        return sd;
+    }
+
+    private long exportMultipleTimes(ExportOptions opts, int times)
+            throws IOException, RepositoryException {
+        long size = 0;
+        for (int i = 0 ; i < times ; i++) {
+            WriteCountOutputStream outputStream = new WriteCountOutputStream();
+            packMgr.assemble(admin, opts, outputStream);
+            size += outputStream.size();
+        }
+        return size;
+    }
+
+    private ExportOptions buildExportOptions(String nodePath, int level) {
+        ExportOptions opts = new ExportOptions();
+        opts.setCompressionLevel(level);
+        DefaultMetaInf inf = new DefaultMetaInf();
+        DefaultWorkspaceFilter filter = new DefaultWorkspaceFilter();
+        filter.add(new PathFilterSet(nodePath));
+        inf.setFilter(filter);
+        Properties props = new Properties();
+        props.setProperty(VaultPackage.NAME_GROUP, "jackrabbit/test");
+        props.setProperty(VaultPackage.NAME_NAME, "test-compression-package");
+        inf.setProperties(props);
+        opts.setMetaInf(inf);
+        return opts;
+    }
+
+
+    private String storeFile(boolean compressible, String mimeType, int size)
+            throws RepositoryException {
+        String path = String.format("%s/%s", TEST_PARENT_PATH, fileName(compressible, mimeType, size));
+        Node node = JcrUtils.getOrCreateByPath(path, "nt:unstructured", admin);
+        byte[] data = compressible ? compressibleData(size) : incompressibleData(size);
+        JcrUtils.putFile(node, "file", mimeType, new ByteArrayInputStream(data));
+        admin.save();
+        return node.getPath();
+    }
+
+    private String fileName(boolean compressible, String mimeType, int size) {
+        return String.format("%s_%s_%s", mimeType, size, compressible ? "compressible" : "incompressible");
+    }
+
+    private byte[] compressibleData(int length) {
+        byte[] data = new byte[length];
+        Arrays.fill(data, (byte)42); // low entropy data
+        return data;
+    }
+
+    private byte[] incompressibleData(int length) {
+        byte[] data = new byte[length];
+        RAND.nextBytes(data); // high entropy data
+        return data;
+    }
+
+    public class WriteCountOutputStream extends OutputStream {
+
+        long size = 0;
+
+        @Override
+        public void write(int b) throws IOException {
+            size++;
+        }
+
+        @Override
+        public void write(byte[] b) throws IOException {
+            size += b.length;
+        }
+
+        @Override
+        public void write(byte[] b, int off, int len) throws IOException {
+            size += len;
+        }
+
+        public long size() {
+            return size;
+        }
+    }
+
+    private class SizeDuration {
+
+        long size;
+
+        long duration;
+
+        SizeDuration(long size, long duration) {
+            this.duration = duration;
+            this.size = size;
+        }
+    }
+
+}


### PR DESCRIPTION
Allowing to define compression levels (JCRVLT-164) is covered.
The compression level can optionally be set via the ExportOptions.
The default compression level is backward compatible (DEFAULT_COMPRESSION).

The binary optimization (JCRVLT-163) is enabled depending on the compression level.
The DEFAULT_COMPRESSION, NO_COMPRESSION and BEST_COMPRESSION levels do not enable
the binary optimization, the remaining levels do.

The min length threshold to run the auto-detection binary optimization is defined
such that in the worst case (data is compressible) the cost required to run the
auto-detection is no bigger than 3% of the cost to compress the same data.
The parameters in place should be tweaked.