### PR TITLE
unix script java version check

### DIFF
--- a/vault-cli/src/main/appassembler/unix-template.sh
+++ b/vault-cli/src/main/appassembler/unix-template.sh
@@ -121,7 +121,8 @@ if [ -n "$COLS" ]; then
     EXTRA_JVM_ARGUMENTS="$EXTRA_JVM_ARGUMENTS -Denv.term.width=${COLS}"
 fi
 
-JAVA_VER=$($JAVACMD -version 2>&1 | sed 's/java version "\(.*\)\.\(.*\)\..*"/\1\2/; 1q')
+#JAVA_VER=$($JAVACMD -version 2>&1 | sed 's/java version "\(.*\)\.\(.*\)\..*"/\1\2/; 1q')
+JAVA_VER=$($JAVACMD -version 2>&1 | sed -n ';s/.* version "\(.*\)\.\(.*\)\..*"/\1\2/p;')
 
 if [ "$JAVA_VER" -lt 18 ]; then
     EXTRA_JVM_ARGUMENTS="$EXTRA_JVM_ARGUMENTS -XX:PermSize=128m -XX:-UseGCOverheadLimit"


### PR DESCRIPTION
when using vlt with openjdk the unix script rises a version check error, this is solved by changing the version parse.