### PR TITLE
JCRVLT-197 AggregateImpl.includesProperty fails with multiple filter roots

### DIFF
--- a/vault-core/src/main/java/org/apache/jackrabbit/vault/fs/api/WorkspaceFilter.java
+++ b/vault-core/src/main/java/org/apache/jackrabbit/vault/fs/api/WorkspaceFilter.java
@@ -67,6 +67,16 @@ public interface WorkspaceFilter extends Dumpable {
     boolean contains(String path);
 
     /**
+     * Checks if the given path of a node's property is contained in this workspace filter.
+     * It returns {@code true} if any of the filter sets contain the path
+     * and it's not globally ignored.
+     *
+     * @param path to check
+     * @return {@code true} if the given path is included in this filter.
+     */
+    boolean containsProperty(String path);
+
+    /**
      * Checks if the given node path is covered in this workspace filter.
      * It only returns {@code true} if at least one of the sets covers
      * the path and is not globally ignored.

--- a/vault-core/src/main/java/org/apache/jackrabbit/vault/fs/config/DefaultWorkspaceFilter.java
+++ b/vault-core/src/main/java/org/apache/jackrabbit/vault/fs/config/DefaultWorkspaceFilter.java
@@ -173,6 +173,18 @@ public class DefaultWorkspaceFilter implements Dumpable, WorkspaceFilter {
     /**
      * {@inheritDoc}
      */
+    public boolean containsProperty(String path) {
+        for (PathFilterSet set: propsFilterSets) {
+            if (set.contains(path)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
     public boolean covers(String path) {
         if (isGloballyIgnored(path)) {
             return false;

--- a/vault-core/src/main/java/org/apache/jackrabbit/vault/fs/config/DefaultWorkspaceFilter.java
+++ b/vault-core/src/main/java/org/apache/jackrabbit/vault/fs/config/DefaultWorkspaceFilter.java
@@ -97,18 +97,22 @@ public class DefaultWorkspaceFilter implements Dumpable, WorkspaceFilter {
 
     /**
      * Add a #PathFilterSet for nodes items.
+     * Generate appropriate #PathFilterSet for corresponding properties items.
      * @param set the set of filters to add.
      */
     public void add(PathFilterSet set) {
         nodesFilterSets.add(set);
+        propsFilterSets.add(new PathFilterSet(set.getRoot()));
     }
 
     /**
-     * Add a #PathFilterSet for properties items.
-     * @param set the set of filters to add.
+     * Add #PathFilterSet for nodes items and properties items.
+     * @param nodesFilterSet the set of node filters to add.
+     * @param propertiesFilterSet the set of property filters to add.
      */
-    public void addPropertyFilterSet(PathFilterSet set) {
-        propsFilterSets.add(set);
+    public void add(PathFilterSet nodesFilterSet, PathFilterSet propertiesFilterSet) {
+        nodesFilterSets.add(nodesFilterSet);
+        propsFilterSets.add(propertiesFilterSet);
     }
 
     /**
@@ -228,10 +232,10 @@ public class DefaultWorkspaceFilter implements Dumpable, WorkspaceFilter {
             mapped.setGlobalIgnored(globalIgnored.translate(mapping));
         }
         for (PathFilterSet set: nodesFilterSets) {
-            mapped.add(set.translate(mapping));
+            mapped.nodesFilterSets.add(set.translate(mapping));
         }
         for (PathFilterSet set: propsFilterSets) {
-            mapped.addPropertyFilterSet(set.translate(mapping));
+            mapped.propsFilterSets.add(set.translate(mapping));
         }
         return mapped;
     }
@@ -356,8 +360,7 @@ public class DefaultWorkspaceFilter implements Dumpable, WorkspaceFilter {
                 }
             }
         }
-        add(nodeFilters);
-        addPropertyFilterSet(propFilters);
+        add(nodeFilters, propFilters);
     }
 
     protected PathFilter readFilter(Element elem) throws ConfigurationException {

--- a/vault-core/src/main/java/org/apache/jackrabbit/vault/fs/impl/AggregateImpl.java
+++ b/vault-core/src/main/java/org/apache/jackrabbit/vault/fs/impl/AggregateImpl.java
@@ -572,15 +572,6 @@ public class AggregateImpl implements Aggregate {
         }
     }
 
-    private boolean includesProperty(String propertyPath) {
-        for (PathFilterSet filterSet: mgr.getWorkspaceFilter().getPropertyFilterSets()) {
-            if (!filterSet.contains(propertyPath)) {
-                return false;
-            }
-        }
-        return true;
-    }
-
     private void addNamespace(Set<String> prefixes, String name) throws RepositoryException {
         int idx = name.indexOf(':');
         if (idx > 0) {
@@ -685,7 +676,8 @@ public class AggregateImpl implements Aggregate {
         while (pIter.hasNext()) {
             Property p = pIter.nextProperty();
             String path = p.getPath();
-            if (aggregator.includes(getNode(), node, p, path) && includesProperty(path)) {
+            if (aggregator.includes(getNode(), node, p, path) &&
+                    mgr.getWorkspaceFilter().containsProperty(path)) {
                 include(node, p, path);
             }
         }

--- a/vault-core/src/test/java/org/apache/jackrabbit/vault/packaging/integration/TestFilteredPropertyExport.java
+++ b/vault-core/src/test/java/org/apache/jackrabbit/vault/packaging/integration/TestFilteredPropertyExport.java
@@ -17,6 +17,7 @@
 
 package org.apache.jackrabbit.vault.packaging.integration;
 
+import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
 import java.util.Properties;
@@ -27,6 +28,7 @@ import javax.jcr.Session;
 
 import org.apache.jackrabbit.vault.fs.api.PathFilterSet;
 import org.apache.jackrabbit.vault.fs.api.WorkspaceFilter;
+import org.apache.jackrabbit.vault.fs.config.ConfigurationException;
 import org.apache.jackrabbit.vault.fs.config.DefaultMetaInf;
 import org.apache.jackrabbit.vault.fs.config.DefaultWorkspaceFilter;
 import org.apache.jackrabbit.vault.fs.filter.DefaultPathFilter;
@@ -52,6 +54,7 @@ public class TestFilteredPropertyExport extends IntegrationTestBase {
     public void noPropertyFiltered() throws IOException, RepositoryException, PackageException {
         DefaultWorkspaceFilter filter = new DefaultWorkspaceFilter();
         filter.add(new PathFilterSet("/tmp"));
+        filter.addPropertyFilterSet(new PathFilterSet("/tmp"));
         // export and extract
         File pkgFile = assemblePackage(filter);
         clean("/tmp");
@@ -89,6 +92,51 @@ public class TestFilteredPropertyExport extends IntegrationTestBase {
         PathFilterSet properties = new PathFilterSet("/tmp");
         properties.addExclude(new DefaultPathFilter("/tmp/foo/p.*"));
         filter.addPropertyFilterSet(properties);
+        // export and extract
+        File pkgFile = assemblePackage(filter);
+        clean("/tmp");
+        packMgr.open(pkgFile).extract(admin, getDefaultOptions());
+        // validate the extracted content
+        assertPropertiesExist("/tmp", "p1", "p2", "p3");
+        assertPropertiesMissg("/tmp/foo", "p1", "p2", "p3");
+        assertPropertiesExist("/tmp/foo/bar", "p1", "p2", "p3");
+    }
+
+    @Test
+    public void filterPropertyWithTwoRoots() throws IOException, RepositoryException, PackageException {
+
+        DefaultWorkspaceFilter filter = new DefaultWorkspaceFilter();
+        filter.add(new PathFilterSet("/foo"));
+        filter.addPropertyFilterSet(new PathFilterSet("/foo"));
+        filter.add(new PathFilterSet("/tmp"));
+
+        PathFilterSet properties = new PathFilterSet("/tmp");
+        properties.addExclude(new DefaultPathFilter("/tmp/foo/p.*"));
+        filter.addPropertyFilterSet(properties);
+
+        // export and extract
+        File pkgFile = assemblePackage(filter);
+        clean("/tmp");
+        packMgr.open(pkgFile).extract(admin, getDefaultOptions());
+        // validate the extracted content
+        assertPropertiesExist("/tmp", "p1", "p2", "p3");
+        assertPropertiesMissg("/tmp/foo", "p1", "p2", "p3");
+        assertPropertiesExist("/tmp/foo/bar", "p1", "p2", "p3");
+    }
+
+    @Test
+    public void filterPropertyFromSource() throws IOException, RepositoryException, PackageException, ConfigurationException {
+        String src = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+                "<workspaceFilter version=\"1.0\">\n" +
+                "    <filter root=\"/foo\"/>\n" +
+                "    <filter root=\"/tmp\">\n" +
+                "        <exclude pattern=\"/tmp/foo/p.*\" matchProperties=\"true\"/>\n" +
+                "    </filter>\n" +
+                "</workspaceFilter>";
+
+        DefaultWorkspaceFilter filter = new DefaultWorkspaceFilter();
+        filter.load(new ByteArrayInputStream(src.getBytes("utf-8")));
+
         // export and extract
         File pkgFile = assemblePackage(filter);
         clean("/tmp");

--- a/vault-core/src/test/java/org/apache/jackrabbit/vault/packaging/integration/TestFilteredPropertyExport.java
+++ b/vault-core/src/test/java/org/apache/jackrabbit/vault/packaging/integration/TestFilteredPropertyExport.java
@@ -54,7 +54,6 @@ public class TestFilteredPropertyExport extends IntegrationTestBase {
     public void noPropertyFiltered() throws IOException, RepositoryException, PackageException {
         DefaultWorkspaceFilter filter = new DefaultWorkspaceFilter();
         filter.add(new PathFilterSet("/tmp"));
-        filter.addPropertyFilterSet(new PathFilterSet("/tmp"));
         // export and extract
         File pkgFile = assemblePackage(filter);
         clean("/tmp");
@@ -68,11 +67,10 @@ public class TestFilteredPropertyExport extends IntegrationTestBase {
     @Test
     public void filterPropertyP1OnFoo() throws IOException, RepositoryException, PackageException {
         DefaultWorkspaceFilter filter = new DefaultWorkspaceFilter();
-        filter.add(new PathFilterSet("/tmp"));
 
         PathFilterSet properties = new PathFilterSet("/tmp");
         properties.addExclude(new DefaultPathFilter("/tmp/foo/p1"));
-        filter.addPropertyFilterSet(properties);
+        filter.add(new PathFilterSet("/tmp"), properties);
         // export and extract
         File pkgFile = assemblePackage(filter);
         clean("/tmp");
@@ -87,11 +85,10 @@ public class TestFilteredPropertyExport extends IntegrationTestBase {
     @Test
     public void filterPropertyPxOnFoo() throws IOException, RepositoryException, PackageException {
         DefaultWorkspaceFilter filter = new DefaultWorkspaceFilter();
-        filter.add(new PathFilterSet("/tmp"));
 
         PathFilterSet properties = new PathFilterSet("/tmp");
         properties.addExclude(new DefaultPathFilter("/tmp/foo/p.*"));
-        filter.addPropertyFilterSet(properties);
+        filter.add(new PathFilterSet("/tmp"), properties);
         // export and extract
         File pkgFile = assemblePackage(filter);
         clean("/tmp");
@@ -107,12 +104,10 @@ public class TestFilteredPropertyExport extends IntegrationTestBase {
 
         DefaultWorkspaceFilter filter = new DefaultWorkspaceFilter();
         filter.add(new PathFilterSet("/foo"));
-        filter.addPropertyFilterSet(new PathFilterSet("/foo"));
-        filter.add(new PathFilterSet("/tmp"));
 
         PathFilterSet properties = new PathFilterSet("/tmp");
         properties.addExclude(new DefaultPathFilter("/tmp/foo/p.*"));
-        filter.addPropertyFilterSet(properties);
+        filter.add(new PathFilterSet("/tmp"), properties);
 
         // export and extract
         File pkgFile = assemblePackage(filter);
@@ -150,11 +145,10 @@ public class TestFilteredPropertyExport extends IntegrationTestBase {
     @Test
     public void filterRelativeProperties() throws IOException, RepositoryException, PackageException {
         DefaultWorkspaceFilter filter = new DefaultWorkspaceFilter();
-        filter.add(new PathFilterSet("/tmp"));
 
         PathFilterSet properties = new PathFilterSet("/tmp");
         properties.addExclude(new DefaultPathFilter(".*/p1"));
-        filter.addPropertyFilterSet(properties);
+        filter.add(new PathFilterSet("/tmp"), properties);
         // export and extract
         File pkgFile = assemblePackage(filter);
         clean("/tmp");


### PR DESCRIPTION
This should help fixing the issues with properties and workspace filters
https://issues.apache.org/jira/browse/JCRVLT-197

I moved the `containsProperty` to WorkspaceFilter in order to show similar algorithm with `contains`.
I also assumed the properties of an ancestor are always included.