### PR TITLE
Add feature to handover package properties to JCR Events.

### DIFF
--- a/vault-core/src/main/java/org/apache/jackrabbit/vault/packaging/JcrPackage.java
+++ b/vault-core/src/main/java/org/apache/jackrabbit/vault/packaging/JcrPackage.java
@@ -54,6 +54,12 @@ public interface JcrPackage extends Comparable<JcrPackage>, AutoCloseable {
      */
     String MIME_TYPE = "application/zip";
 
+    
+    /**
+     * Configuration property which is passed as userdata in observation events
+     */
+    String PROP_USERDATA = "eventUserData";
+    
     /**
      * Returns the package definition of this package
      * @return the package definition or {@code null} if this package is

--- a/vault-core/src/main/java/org/apache/jackrabbit/vault/packaging/impl/JcrPackageImpl.java
+++ b/vault-core/src/main/java/org/apache/jackrabbit/vault/packaging/impl/JcrPackageImpl.java
@@ -414,6 +414,8 @@ public class JcrPackageImpl implements JcrPackage {
             snap = snapshot(eOpts, replaceSnapshot, opts.getAccessControlHandling());
         }
         List<String> subPackages = new ArrayList<String>();
+        String userData = pack.getProperty(PROP_USERDATA);
+        node.getSession().getWorkspace().getObservationManager().setUserData(userData);
         pack.extract(ctx, subPackages);
         if (def != null && !opts.isDryRun()) {
             def.touchLastUnpacked(null, true);
@@ -499,6 +501,8 @@ public class JcrPackageImpl implements JcrPackage {
             for (JcrPackageImpl p: subPacks) {
                 boolean skip = false;
                 PackageId id = p.getDefinition().getId();
+                String userSessionData = p.getPackage().getProperty(PROP_USERDATA);
+                s.getWorkspace().getObservationManager().setUserData(userSessionData);
                 SubPackageHandling.Option option = sb.getOption(id);
                 String msg;
                 if (option == SubPackageHandling.Option.ADD || option == SubPackageHandling.Option.IGNORE) {


### PR DESCRIPTION
It's sometime useful if you can provide a flag/string in a content package, which can be evaluated in the JCR observation handlers using ```event.getUserData()```.

The flag must be set in the ```properties.xml``` like this

```
<entry key="eventUserData">myValue</entry>
```