### PR TITLE
improve logging for tests

### DIFF
--- a/vault-core/pom.xml
+++ b/vault-core/pom.xml
@@ -160,6 +160,12 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <version>1.0.13</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
             <scope>provided</scope>

--- a/vault-core/src/test/resources/logback.xml
+++ b/vault-core/src/test/resources/logback.xml
@@ -1,0 +1,14 @@
+<configuration>
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <logger name="org.apache.jackrabbit.oak.query.QueryImpl" level="WARN"/>
+  <logger name="org.apache.jackrabbit.oak.plugins.index.IndexUpdate" level="WARN" />
+
+  <root level="INFO">
+    <appender-ref ref="STDOUT" />
+  </root>
+</configuration>


### PR DESCRIPTION
use a logback configuration for logging output of tests and ignore a lot of Oak messages when running with "-Doak"