### PR TITLE
Add rudimentary support for controlling the line separator

### DIFF
--- a/vault-cli/src/main/appassembler/unix-template.sh
+++ b/vault-cli/src/main/appassembler/unix-template.sh
@@ -13,12 +13,13 @@
 #    e.g. to debug vault itself, use
 #      set VLT_OPTS=-Xdebug -Xnoagent -Djava.compiler=NONE -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=8000
 #
-#    LINE SEPARATOR
-#    To force vault to use a particular line separator regardless of the operating system's native line separator (default), you
-#    can inject -Dline.separator=$'\r'$'\n' or -Dline.separator=$'\n' into the exec line where VLT_OPTS is used; it might
-#    also be possible to embed that in the VLT_OPTS variable but that has proven problematic.  Perhaps VLT will support such a
-#    configuration as a native option in the future and call System.setProperties("line.separator",lsep) which also works
-#----------------------------------------------------------------------------
+# LINE SEPARATOR
+# Because it can be pretty tricky to shove a newline character into a batch or shell script and the text "\n" doesn't get
+# interpreted as what you might think by Java, vlt will instead look for LF | CRLF in a system property called vlt.line.separator
+# and if it exists, it will set the appropriate Java System property accordingly, e.g. -Dvlt.line.separator=LF
+# ----------------------------------------------------------------------------
+
+VLT_OPTS=-Dvlt.line.separator=LF
 
 if [ -f /etc/vaultrc ] ; then
   . /etc/vaultrc

--- a/vault-cli/src/main/appassembler/unix-template.sh
+++ b/vault-cli/src/main/appassembler/unix-template.sh
@@ -12,6 +12,12 @@
 #  VLT_OPTS - parameters passed to the Java VM when running Vault
 #    e.g. to debug vault itself, use
 #      set VLT_OPTS=-Xdebug -Xnoagent -Djava.compiler=NONE -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=8000
+#
+#    LINE SEPARATOR
+#    To force vault to use a particular line separator regardless of the operating system's native line separator (default), you
+#    can inject -Dline.separator=$'\r'$'\n' or -Dline.separator=$'\n' into the exec line where VLT_OPTS is used; it might
+#    also be possible to embed that in the VLT_OPTS variable but that has proven problematic.  Perhaps VLT will support such a
+#    configuration as a native option in the future and call System.setProperties("line.separator",lsep) which also works
 #----------------------------------------------------------------------------
 
 if [ -f /etc/vaultrc ] ; then
@@ -122,6 +128,7 @@ if [ -n "$COLS" ]; then
 fi
 
 JAVA_VER=$($JAVACMD -version 2>&1 | sed 's/.*version "\(.*\)\.\(.*\)\..*"/\1\2/; 1q')
+JAVA_VER="${JAVA_VER//[[:space:]]/}"
 
 if [ "$JAVA_VER" -lt 18 ]; then
     EXTRA_JVM_ARGUMENTS="$EXTRA_JVM_ARGUMENTS -XX:PermSize=128m -XX:-UseGCOverheadLimit"

--- a/vault-cli/src/main/appassembler/windows-template.bat
+++ b/vault-cli/src/main/appassembler/windows-template.bat
@@ -11,7 +11,14 @@
 @REM VLT_OPTS - parameters passed to the Java VM when running vlt
 @REM     e.g. to debug vlt itself, use
 @REM set VLT_OPTS=-Xdebug -Xnoagent -Djava.compiler=NONE -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=8000
+@REM 
+@REM LINE SEPARATOR
+@REM Because it can be pretty tricky to shove a newline character into a batch or shell script and the text "\n" doesn't get
+@REM interpreted as what you might think by Java, vlt will instead look for LF | CRLF in a system property called vlt.line.separator
+@REM and if it exists, it will set the appropriate Java System property accordingly, e.g. -Dvlt.line.separator=LF
 @REM ----------------------------------------------------------------------------
+
+set VLT_OPTS=-Dvlt.line.separator=LF
 
 @REM Begin all REM lines with '@' in case VLT_BATCH_ECHO is 'on'
 @echo off

--- a/vault-cli/src/main/java/org/apache/jackrabbit/vault/cli/VaultFsApp.java
+++ b/vault-cli/src/main/java/org/apache/jackrabbit/vault/cli/VaultFsApp.java
@@ -123,6 +123,23 @@ public class VaultFsApp extends AbstractApplication {
     private Console console;
 
     public static void main(String[] args) {
+	String vltSep = System.getProperty("vlt.line.separator");
+	if ( vltSep != null ) {
+	  System.out.println("Attempting to set line separator property to: " + vltSep);
+	  if ( vltSep.equals("LF") ) {
+	    System.out.println("Attempting to set line separator property to newline");
+	    System.setProperty("line.separator","\n");
+	  }
+	  else if ( vltSep.equals("CRLF") ) {
+	    System.out.println("Attempting to set line separator property to carriage return + newline");
+	    System.setProperty("line.separator","\r\n");
+	  }
+	  else {
+	    System.out.println("Invalid vlt.line.separator - supported options: LF, CRLF");
+	    System.exit(1);
+	  }
+    	}
+
         new VaultFsApp().run(args);
     }
 


### PR DESCRIPTION
Requiring SVN settings to change in order to adapt to vlt's inability to control the line separator being used, combined with the surprising (fact?) that it's impossible to create a working windows batch file that passes chr(10) on the command line to -Dline.separator and the fact that it's a bit tricky to do with bash, led me to creating this patch that allows a custom vlt.line.separator system property to be set to a text value of either LF or CRLF which is then read in main() and set accordingly.  I realize that this approach would probably need to be adapted to conform with vlt's settings (or at least to accept a new command line option) but I didn't have the time to investigate that route.  I'm hoping the existence of this pull request and the utility it provides in giving teams control over the line separator so that the JCR, version control systems, and vlt can work harmoniously together regardless of which operating system is used.  For example, since vlt on Mac presumably defaults to LF, a team comprised of developers using Windows and Macs cannot all use vlt since they would be creating files that are detected by their version control system as being different due to the line separator differences that vlt creates across those systems.