### PR TITLE
JCRVLT-319 - allow definition of packageIds that are externally satis…

### DIFF
--- a/vault-core/src/main/java/org/apache/jackrabbit/vault/packaging/registry/ExecutionPlanBuilder.java
+++ b/vault-core/src/main/java/org/apache/jackrabbit/vault/packaging/registry/ExecutionPlanBuilder.java
@@ -103,7 +103,7 @@ public interface ExecutionPlanBuilder {
      * @throws PackageException if the plan is not valid.
      */
     @Nonnull
-    List<PackageId> calculate() throws IOException, PackageException;
+    List<PackageId> calculateIds() throws IOException, PackageException;
     
     /**
      * builds an executes the plan synchronously.

--- a/vault-core/src/main/java/org/apache/jackrabbit/vault/packaging/registry/ExecutionPlanBuilder.java
+++ b/vault-core/src/main/java/org/apache/jackrabbit/vault/packaging/registry/ExecutionPlanBuilder.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.List;
+import java.util.Set;
 
 import javax.annotation.Nonnull;
 import javax.jcr.Session;
@@ -98,12 +99,12 @@ public interface ExecutionPlanBuilder {
     /**
      * Triggers Validation and returns PackageIds of all packages to be installed
      * by this builder
-     * @return List of packages to be installed by this builder.
+     * @return Set of packages to be installed by this builder.
      * @throws IOException if an I/O error occurrs.
      * @throws PackageException if the plan is not valid.
      */
     @Nonnull
-    List<PackageId> calculateIds() throws IOException, PackageException;
+    Set<PackageId> preview() throws IOException, PackageException;
     
     /**
      * builds an executes the plan synchronously.

--- a/vault-core/src/main/java/org/apache/jackrabbit/vault/packaging/registry/ExecutionPlanBuilder.java
+++ b/vault-core/src/main/java/org/apache/jackrabbit/vault/packaging/registry/ExecutionPlanBuilder.java
@@ -19,12 +19,14 @@ package org.apache.jackrabbit.vault.packaging.registry;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.util.List;
 
 import javax.annotation.Nonnull;
 import javax.jcr.Session;
 
 import org.apache.jackrabbit.vault.fs.api.ProgressTrackerListener;
 import org.apache.jackrabbit.vault.packaging.PackageException;
+import org.apache.jackrabbit.vault.packaging.PackageId;
 import org.osgi.annotation.versioning.ProviderType;
 
 /**
@@ -84,6 +86,25 @@ public interface ExecutionPlanBuilder {
     @Nonnull
     ExecutionPlanBuilder with(@Nonnull ProgressTrackerListener listener);
 
+    
+    /**
+     * Sets packages handled externally ahead of execution for prevalidation of plan
+     * @param List of packages handled by other builder
+     * @return this.
+     */
+    @Nonnull
+    ExecutionPlanBuilder with(@Nonnull List<PackageId> externalPackages);
+
+    /**
+     * Triggers Validation and returns PackageIds of all packages to be installed
+     * by this builder
+     * @return List of packages to be installed by this builder.
+     * @throws IOException if an I/O error occurrs.
+     * @throws PackageException if the plan is not valid.
+     */
+    @Nonnull
+    List<PackageId> calculate() throws IOException, PackageException;
+    
     /**
      * builds an executes the plan synchronously.
      * @return the execution plan.

--- a/vault-core/src/main/java/org/apache/jackrabbit/vault/packaging/registry/impl/ExecutionPlanBuilderImpl.java
+++ b/vault-core/src/main/java/org/apache/jackrabbit/vault/packaging/registry/impl/ExecutionPlanBuilderImpl.java
@@ -278,7 +278,7 @@ public class ExecutionPlanBuilderImpl implements ExecutionPlanBuilder {
             if (task == null) {
                 // package is not registered in plan, but need to be installed
                 // due to dependency
-                task = new PackageTaskImpl(id, PackageTask.Type.INSTALL);
+                task = new PackageTaskImpl(id, type);
             }
             packageTasks.add(task);
         }
@@ -359,7 +359,7 @@ public class ExecutionPlanBuilderImpl implements ExecutionPlanBuilder {
     }
 
     @Override
-    public List<PackageId> calculate() throws IOException, PackageException {
+    public List<PackageId> calculateIds() throws IOException, PackageException {
         validate();
         if (plan.getTasks().size() == 0) {
             return Collections.emptyList();

--- a/vault-core/src/main/java/org/apache/jackrabbit/vault/packaging/registry/impl/ExecutionPlanBuilderImpl.java
+++ b/vault-core/src/main/java/org/apache/jackrabbit/vault/packaging/registry/impl/ExecutionPlanBuilderImpl.java
@@ -359,12 +359,12 @@ public class ExecutionPlanBuilderImpl implements ExecutionPlanBuilder {
     }
 
     @Override
-    public List<PackageId> calculateIds() throws IOException, PackageException {
+    public Set<PackageId> preview() throws IOException, PackageException {
         validate();
         if (plan.getTasks().size() == 0) {
-            return Collections.emptyList();
+            return Collections.emptySet();
         } else {
-            List<PackageId> packages = new ArrayList<>();
+            Set<PackageId> packages = new HashSet<>();
             for(PackageTask task : plan.getTasks()) {
                 packages.add(task.getPackageId());
             }

--- a/vault-core/src/main/java/org/apache/jackrabbit/vault/packaging/registry/impl/FSPackageRegistry.java
+++ b/vault-core/src/main/java/org/apache/jackrabbit/vault/packaging/registry/impl/FSPackageRegistry.java
@@ -20,7 +20,6 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Collection;
@@ -145,15 +144,11 @@ public class FSPackageRegistry extends AbstractPackageRegistry {
 
     @Activate
     private void activate(BundleContext context, Config config) throws IOException {
-        Path homePath = Paths.get(config.homePath());
-        if (homePath.isAbsolute()) {
-            this.homeDir = homePath.toFile();
+        String repoHome = context.getProperty(REPOSITORY_HOME);
+        if (repoHome == null) {
+            this.homeDir = context.getDataFile(config.homePath());
         } else {
-            String repoHome = context.getProperty(REPOSITORY_HOME);
-            if (repoHome == null) {
-                throw new IOException("Can't lookup relative path when property repository.home is not set");
-            }
-            this.homeDir = new File(repoHome + "/" + homePath.toString());
+            this.homeDir = new File(repoHome + "/" + config.homePath());
             if (!homeDir.exists()) {
                 homeDir.mkdirs();
             }

--- a/vault-core/src/test/java/org/apache/jackrabbit/vault/packaging/integration/TestExecutionPlan.java
+++ b/vault-core/src/test/java/org/apache/jackrabbit/vault/packaging/integration/TestExecutionPlan.java
@@ -345,12 +345,12 @@ public class TestExecutionPlan extends IntegrationTestBase {
                 .addTask().with(idA).with(PackageTask.Type.EXTRACT)
                 .with(admin)
                 .with(getDefaultOptions().getListener());
-        assertEquals("builder2 contains all packageTasks", 3, builder2.calculateIds().size());
+        assertEquals("builder2 contains all packageTasks", 3, builder2.preview().size());
         
         // If calculatedIds of builder1 are declared external idB & idC should be removed
-        builder2.with(builder1.calculateIds());
-        assertEquals("builder2 only contains 1 PackageTask", 1, builder2.calculateIds().size());
-        assertEquals("builder2 handles only idA", builder2.calculateIds().get(0), idA);
+        builder2.with(builder1.preview());
+        assertEquals("builder2 only contains 1 PackageTask", 1, builder2.preview().size());
+        assertEquals("builder2 handles only idA", builder2.preview().get(0), idA);
         
         ExecutionPlan plan = builder2.execute();
         assertTrue("builder2 should fail before builder1 is executed.",plan.hasErrors());
@@ -358,7 +358,7 @@ public class TestExecutionPlan extends IntegrationTestBase {
         builder1.execute();
         
         // revalidate builder2 to reset error state (calculate implicitly validates)
-        assertEquals("builder2 only contains 1 PackageTask", 1, builder2.calculateIds().size());
+        assertEquals("builder2 only contains 1 PackageTask", 1, builder2.preview().size());
         
         ExecutionPlan plan2 = builder2.execute();
         assertFalse("builder2 should succeed after builder1 has been executed.", plan2.hasErrors());


### PR DESCRIPTION
…fied when building executinplan - consumer takes over responsibility to install those upfront (allows building of stacked executionplans)