### PR TITLE
JCRVLT-322 - check to check against Path object instead of String rep…

### DIFF
--- a/vault-core/src/main/java/org/apache/jackrabbit/vault/packaging/registry/impl/FSPackageRegistry.java
+++ b/vault-core/src/main/java/org/apache/jackrabbit/vault/packaging/registry/impl/FSPackageRegistry.java
@@ -20,6 +20,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Collection;
@@ -519,8 +520,8 @@ public class FSPackageRegistry extends AbstractPackageRegistry {
     @Nonnull
     @Override
     public PackageId registerExternal(@Nonnull File file, boolean replace) throws IOException, PackageExistsException {
-        if (!replace && pathIdMapping.containsKey(file.getPath())) {
-            throw new PackageExistsException("Package already exists: " + pathIdMapping.get(file.getPath()));
+        if (!replace && pathIdMapping.containsKey(Paths.get(file.getPath()))) {
+            throw new PackageExistsException("Package already exists: " + pathIdMapping.get(file.getPath())).setId(pathIdMapping.get(Paths.get(file.getPath())));
         }
         ZipVaultPackage pack = new ZipVaultPackage(file, false, true);
         try {

--- a/vault-core/src/test/java/org/apache/jackrabbit/vault/packaging/integration/TestFSPackageRegistry.java
+++ b/vault-core/src/test/java/org/apache/jackrabbit/vault/packaging/integration/TestFSPackageRegistry.java
@@ -196,7 +196,7 @@ public class TestFSPackageRegistry extends IntegrationTestBase {
     }
     
     /**
-     * registers a file as external package twice (replace = true)
+     * registers a file as external package twice (replace = false)
      */
     @Test
     public void testRegisterExternalFileTwiceFails() throws IOException, PackageException {
@@ -218,9 +218,36 @@ public class TestFSPackageRegistry extends IntegrationTestBase {
             assertEquals("colliding pid must be correct", id, e.getId());
         }
     }
+    
+    /**
+     * registers a file as external package twice with 
+     */
+    @Test
+    public void testRegisterExternalFileTwiceFailsLoadedRegistry() throws IOException, PackageException {
+        File file = getTempFile("testpackages/tmp.zip");
+        PackageId id = registry.registerExternal(file, false);
+        assertEquals("package id", TMP_PACKAGE_ID, id);
+
+        try (RegisteredPackage pkg = registry.open(id)) {
+            assertEquals("package id of registered is correct", TMP_PACKAGE_ID, pkg.getId());
+            assertFalse("Package is not installed", pkg.isInstalled());
+        }
+        
+        // loading registry again to force loading of metadata from files
+        registry = new FSPackageRegistry(DIR_REGISTRY_HOME);
+        
+        try {
+            registry.registerExternal(file, false);
+            fail("registering the package twice should fail");
+        } catch (PackageExistsException e) {
+            // expected
+            assertEquals("colliding pid must be correct", id, e.getId());
+        }
+    }
+
 
     /**
-     * registers a file as external package twice (replace = true)
+     * registers a file as external package twice (replace = false)
      */
     @Test
     public void testRegisterExternalFileTwiceSucceeds() throws IOException, PackageException {


### PR DESCRIPTION
…resentation (always failing falling back to the expensive FIle check)