### PR TITLE
JCRVLT-323 upgrade to Jackrabbit 2.16.4 to benefit from

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -40,7 +40,7 @@
     </description>
 
     <properties>
-        <jackrabbit.version>2.16.3</jackrabbit.version>
+        <jackrabbit.version>2.16.4</jackrabbit.version>
         <oak.version>1.6.1</oak.version>
         <slf4j.version>1.7.6</slf4j.version>
         <test.oak>false</test.oak>

--- a/vault-core/src/main/java/org/apache/jackrabbit/vault/util/RepositoryCopier.java
+++ b/vault-core/src/main/java/org/apache/jackrabbit/vault/util/RepositoryCopier.java
@@ -212,7 +212,7 @@ public class RepositoryCopier {
                 if (srcCreds == null && credentialsProvider != null) {
                     srcCreds = credentialsProvider.getCredentials(src);
                 }
-                srcSession = login(srcRepo, srcCreds, src.getWorkspace());
+                srcSession = srcRepo.login(srcCreds, src.getWorkspace());
             } catch (RepositoryException e) {
                 log.error("Error while logging in src repository {}: {}", src, e.toString());
                 return;
@@ -223,7 +223,7 @@ public class RepositoryCopier {
                 if (dstCreds == null && credentialsProvider != null) {
                     dstCreds = credentialsProvider.getCredentials(dst);
                 }
-                dstSession = login(dstRepo, dstCreds, dst.getWorkspace());
+                dstSession = dstRepo.login(dstCreds, dst.getWorkspace());
             } catch (RepositoryException e) {
                 log.error("Error while logging in dst repository {}: {}", dst, e.toString());
                 return;
@@ -608,18 +608,4 @@ public class RepositoryCopier {
         return credentialsProvider;
     }
 
-
-    private Session login(Repository rep, Credentials credentials, String wspName) throws RepositoryException {
-        try {
-            return rep.login(credentials, wspName);
-        } catch (LoginException e) {
-            if (wspName == null) {
-                // try again with default workspace
-                // todo: make configurable
-                return rep.login(credentials, "crx.default");
-            } else {
-                throw e;
-            }
-        }
-    }
 }

--- a/vault-davex/src/main/java/org/apache/jackrabbit/vault/davex/DAVExRepositoryFactory.java
+++ b/vault-davex/src/main/java/org/apache/jackrabbit/vault/davex/DAVExRepositoryFactory.java
@@ -102,10 +102,10 @@ public class DAVExRepositoryFactory implements RepositoryFactory {
                 );
             }
 
-            // explicit set workspace (JCRVLT-144)
             String workspace = address.getWorkspace();
-            parameters.put(Spi2davexRepositoryServiceFactory.PARAM_WORKSPACE_NAME_DEFAULT, workspace == null ? "" : workspace);
-
+            if (workspace != null) {
+                parameters.put(Spi2davexRepositoryServiceFactory.PARAM_WORKSPACE_NAME_DEFAULT, workspace);
+            }
             System.out.printf("Connecting via JCR remoting to %s%n", address.getSpecificURI().toString());
             return new RepositoryFactoryImpl().getRepository(parameters);
         } catch (IOException e) {


### PR DESCRIPTION
https://issues.apache.org/jira/browse/JCR-4120

Remove obsolete workarounds for default workspace