### PR TITLE
JCRVLT-338 : argLine getting overridden by parent pom and vault-core pom

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -172,7 +172,7 @@
                                 <value>target/derby.log</value>
                             </property>
                         </systemProperties>
-                        <argLine>${test.vm.options}</argLine>
+                        <argLine>>${argLine} ${test.vm.options}</argLine>
                     </configuration>
                 </plugin>
                 <!-- ====================================================================== -->

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -172,7 +172,7 @@
                                 <value>target/derby.log</value>
                             </property>
                         </systemProperties>
-                        <argLine>>${argLine} ${test.vm.options}</argLine>
+                        <argLine>${argLine} ${test.vm.options}</argLine>
                     </configuration>
                 </plugin>
                 <!-- ====================================================================== -->

--- a/vault-core/pom.xml
+++ b/vault-core/pom.xml
@@ -272,7 +272,7 @@
                     <plugin>
                         <artifactId>maven-surefire-plugin</artifactId>
                         <configuration>
-                            <argLine>>${argLine} -Doak=true -Xmx1024m</argLine>
+                            <argLine>${argLine} -Doak=true -Xmx1024m</argLine>
                         </configuration>
                     </plugin>
                 </plugins>
@@ -285,7 +285,7 @@
                     <plugin>
                         <artifactId>maven-surefire-plugin</artifactId>
                         <configuration>
-                            <argLine>>${argLine} -Doak=true -Xmx1024m</argLine>
+                            <argLine>${argLine} -Doak=true -Xmx1024m</argLine>
                         </configuration>
                     </plugin>
                 </plugins>
@@ -310,7 +310,7 @@
                                     <goal>test</goal>
                                 </goals>
                                 <configuration>
-                                    <argLine>>${argLine} -Doak=true -Xmx1024m</argLine>
+                                    <argLine>${argLine} -Doak=true -Xmx1024m</argLine>
                                     <reportNameSuffix>OAK</reportNameSuffix>
                                     <skip>false</skip>
                                 </configuration>

--- a/vault-core/pom.xml
+++ b/vault-core/pom.xml
@@ -272,7 +272,7 @@
                     <plugin>
                         <artifactId>maven-surefire-plugin</artifactId>
                         <configuration>
-                            <argLine>-Doak=true -Xmx1024m</argLine>
+                            <argLine>>${argLine} -Doak=true -Xmx1024m</argLine>
                         </configuration>
                     </plugin>
                 </plugins>
@@ -285,7 +285,7 @@
                     <plugin>
                         <artifactId>maven-surefire-plugin</artifactId>
                         <configuration>
-                            <argLine>-Doak=true -Xmx1024m</argLine>
+                            <argLine>>${argLine} -Doak=true -Xmx1024m</argLine>
                         </configuration>
                     </plugin>
                 </plugins>
@@ -310,7 +310,7 @@
                                     <goal>test</goal>
                                 </goals>
                                 <configuration>
-                                    <argLine>-Doak=true -Xmx1024m</argLine>
+                                    <argLine>>${argLine} -Doak=true -Xmx1024m</argLine>
                                     <reportNameSuffix>OAK</reportNameSuffix>
                                     <skip>false</skip>
                                 </configuration>


### PR DESCRIPTION
argLine needs to be appended rather than overridden.
Not able to install jacoco via cli as the argLine is getting overridden.