### PR TITLE
JCRVLT-338 : argLine getting overridden by parent pom and vault-core pom

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -45,6 +45,7 @@
         <slf4j.version>1.7.6</slf4j.version>
         <test.oak>false</test.oak>
         <test.vm.options>-Doak=$test.oak}</test.vm.options>
+        <argLine>${test.vm.options}</argLine>
     </properties>
 
     <!-- ====================================================================== -->
@@ -172,7 +173,6 @@
                                 <value>target/derby.log</value>
                             </property>
                         </systemProperties>
-                        <argLine>${argLine} ${test.vm.options}</argLine>
                     </configuration>
                 </plugin>
                 <!-- ====================================================================== -->

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -172,7 +172,7 @@
                                 <value>target/derby.log</value>
                             </property>
                         </systemProperties>
-                        <argLine>${test.vm.options}</argLine>
+                        <argLine>${argLine} ${test.vm.options}</argLine>
                     </configuration>
                 </plugin>
                 <!-- ====================================================================== -->


### PR DESCRIPTION
argLine needs to be appended rather than overridden.
Not able to install jacoco via cli as the argLine is getting overridden.