### PR TITLE
JCRVLT-349 clarify and consolidate closing behaviour for input/output

### DIFF
--- a/vault-cli/src/main/java/org/apache/jackrabbit/vault/cli/CmdImportCli.java
+++ b/vault-cli/src/main/java/org/apache/jackrabbit/vault/cli/CmdImportCli.java
@@ -84,13 +84,10 @@ public class CmdImportCli extends AbstractVaultCommand {
                 return;
             }
             // todo: move to another location
-            InputStream ins = FileUtils.openInputStream(localFile);
-            try {
+            try (InputStream ins = FileUtils.openInputStream(localFile)) {
                 Session session = vCtx.getFileSystem(addr).getAggregateManager().getSession();
                 session.getWorkspace().importXML(jcrPath, ins, ImportUUIDBehavior.IMPORT_UUID_COLLISION_REMOVE_EXISTING);
                 return;
-            } finally {
-                IOUtils.closeQuietly(ins);
             }
         }
 

--- a/vault-cli/src/main/java/org/apache/jackrabbit/vault/util/console/AbstractApplication.java
+++ b/vault-cli/src/main/java/org/apache/jackrabbit/vault/util/console/AbstractApplication.java
@@ -331,9 +331,9 @@ public abstract class AbstractApplication {
             return;
         }
         Properties props = new Properties();
-        FileInputStream in = new FileInputStream(file);
-        props.load(in);
-        in.close();
+        try (FileInputStream in = new FileInputStream(file)) {
+            props.load(in);
+        }
         Iterator iter = globalEnv.keySet().iterator();
         while (iter.hasNext()) {
             String key = (String) iter.next();

--- a/vault-cli/src/main/java/org/apache/jackrabbit/vault/util/console/util/PomProperties.java
+++ b/vault-cli/src/main/java/org/apache/jackrabbit/vault/util/console/util/PomProperties.java
@@ -46,11 +46,9 @@ public class PomProperties {
     public Properties getProperties() {
         if (props == null) {
             props = new Properties();
-            try {
-                InputStream in = PomProperties.class.getClassLoader().getResourceAsStream(pomPropsPath);
+            try (InputStream in = PomProperties.class.getClassLoader().getResourceAsStream(pomPropsPath)) {
                 if (in != null) {
                     props.load(in);
-                    in.close();
                 }
             } catch (IOException e) {
                 // ignore

--- a/vault-core/src/main/java/org/apache/jackrabbit/vault/fs/PropertyValueArtifact.java
+++ b/vault-core/src/main/java/org/apache/jackrabbit/vault/fs/PropertyValueArtifact.java
@@ -166,11 +166,10 @@ public class PropertyValueArtifact extends AbstractArtifact implements ExportArt
             tmpFile = File.createTempFile("jcrfs", "dat");
             tmpFile.setLastModified(getLastModified());
             tmpFile.deleteOnExit();
-            FileOutputStream out = new FileOutputStream(tmpFile);
-            InputStream in = getValue().getStream();
-            IOUtils.copy(in, out);
-            in.close();
-            out.close();
+            try (FileOutputStream out = new FileOutputStream(tmpFile);
+                 InputStream in = getValue().getStream()) {
+                IOUtils.copy(in, out);
+            }
         }
     }
 

--- a/vault-core/src/main/java/org/apache/jackrabbit/vault/fs/SerializerArtifact.java
+++ b/vault-core/src/main/java/org/apache/jackrabbit/vault/fs/SerializerArtifact.java
@@ -97,13 +97,13 @@ public class SerializerArtifact extends AbstractArtifact implements ExportArtifa
      * {@inheritDoc}
      */
     public InputStream getInputStream() throws IOException, RepositoryException {
-        DeferredFileOutputStream out = new DeferredFileOutputStream(8192, "vlttmp", ".tmp", null);
-        spool(out);
-        out.close();
-        if (out.isInMemory()) {
-            return new ByteArrayInputStream(out.getData());
-        } else {
-            return new TempFileInputStream(out.getFile());
+        try (DeferredFileOutputStream out = new DeferredFileOutputStream(8192, "vlttmp", ".tmp", null)) {
+            spool(out);
+            if (out.isInMemory()) {
+                return new ByteArrayInputStream(out.getData());
+            } else {
+                return new TempFileInputStream(out.getFile());
+            }
         }
     }
 
@@ -111,17 +111,18 @@ public class SerializerArtifact extends AbstractArtifact implements ExportArtifa
      * {@inheritDoc}
      */
     public VaultInputSource getInputSource() throws IOException, RepositoryException {
-        DeferredFileOutputStream out = new DeferredFileOutputStream(8192, "vlttmp", ".tmp", null);
-        spool(out);
-        out.close();
         final InputStream in;
         final long size;
-        if (out.isInMemory()) {
-            in = new ByteArrayInputStream(out.getData());
-            size = out.getData().length;
-        } else {
-            in = new TempFileInputStream(out.getFile());
-            size = out.getFile().length();
+        try (DeferredFileOutputStream out = new DeferredFileOutputStream(8192, "vlttmp", ".tmp", null)) {
+            spool(out);
+        
+            if (out.isInMemory()) {
+                in = new ByteArrayInputStream(out.getData());
+                size = out.getData().length;
+            } else {
+                in = new TempFileInputStream(out.getFile());
+                size = out.getFile().length();
+            }
         }
         return new VaultInputSource() {
 

--- a/vault-core/src/main/java/org/apache/jackrabbit/vault/fs/VaultFileInputStream.java
+++ b/vault-core/src/main/java/org/apache/jackrabbit/vault/fs/VaultFileInputStream.java
@@ -67,9 +67,9 @@ public class VaultFileInputStream extends InputStream {
                 base = a.getInputStream();
             } else {
                 tmpFile = File.createTempFile("vltfs", ".spool");
-                FileOutputStream out = new FileOutputStream(tmpFile);
-                a.spool(out);
-                out.close();
+                try (FileOutputStream out = new FileOutputStream(tmpFile)) {
+                    a.spool(out);
+                }
                 base = new FileInputStream(tmpFile);
             }
         } catch (RepositoryException e) {

--- a/vault-core/src/main/java/org/apache/jackrabbit/vault/fs/api/Artifact.java
+++ b/vault-core/src/main/java/org/apache/jackrabbit/vault/fs/api/Artifact.java
@@ -117,7 +117,7 @@ public interface Artifact extends Dumpable {
     /**
      * Writes the content to the given output stream and closes it afterwards.
      * This is the preferred method to use for output-artifacts.
-     *
+     * <p>The specified stream remains open after this method returns.
      * @param out the output stream to spool to
      * @throws IOException if an I/O error occurs
      * @throws RepositoryException if a repository error occurs

--- a/vault-core/src/main/java/org/apache/jackrabbit/vault/fs/api/WorkspaceFilter.java
+++ b/vault-core/src/main/java/org/apache/jackrabbit/vault/fs/api/WorkspaceFilter.java
@@ -100,6 +100,8 @@ public interface WorkspaceFilter extends Dumpable {
 
     /**
      * Returns the source xml that constructs this filter
+     * It is the obligation of the caller to close the returned input stream.
+     * 
      * @return the source xml
      */
     @Nonnull

--- a/vault-core/src/main/java/org/apache/jackrabbit/vault/fs/config/SimpleCredentialsConfig.java
+++ b/vault-core/src/main/java/org/apache/jackrabbit/vault/fs/config/SimpleCredentialsConfig.java
@@ -148,11 +148,12 @@ public class SimpleCredentialsConfig extends CredentialsConfig {
             }
             SecretKeySpec key = new SecretKeySpec(data, 0, KEY_LENGTH, "DES");
             Cipher cipher = Cipher.getInstance("DES");
-            ByteArrayOutputStream out = new ByteArrayOutputStream(data.length);
-            cipher.init(Cipher.DECRYPT_MODE, key);
-            out.write(cipher.update(data, KEY_LENGTH, data.length - KEY_LENGTH));
-            out.write(cipher.doFinal());
-            return out.toString("utf-8");
+            try (ByteArrayOutputStream out = new ByteArrayOutputStream(data.length)) {
+                cipher.init(Cipher.DECRYPT_MODE, key);
+                out.write(cipher.update(data, KEY_LENGTH, data.length - KEY_LENGTH));
+                out.write(cipher.doFinal());
+                return out.toString("utf-8");
+            }
         } catch (Exception e) {
             log.warn("Unable to decrypt data: " + e);
             return null;

--- a/vault-core/src/main/java/org/apache/jackrabbit/vault/fs/impl/AbstractArtifact.java
+++ b/vault-core/src/main/java/org/apache/jackrabbit/vault/fs/impl/AbstractArtifact.java
@@ -139,14 +139,13 @@ public abstract class AbstractArtifact implements Artifact {
      */
     public void spool(OutputStream out)
             throws IOException, RepositoryException {
-        InputStream in = getInputStream();
-        byte[] buffer = new byte[8192];
-        int read;
-        while ((read = in.read(buffer)) >= 0) {
-            out.write(buffer, 0, read);
+        try (InputStream in = getInputStream()) {
+            byte[] buffer = new byte[8192];
+            int read;
+            while ((read = in.read(buffer)) >= 0) {
+                out.write(buffer, 0, read);
+            }
         }
-        in.close();
-        out.close();
     }
 
     /**

--- a/vault-core/src/main/java/org/apache/jackrabbit/vault/fs/impl/AggregateManagerImpl.java
+++ b/vault-core/src/main/java/org/apache/jackrabbit/vault/fs/impl/AggregateManagerImpl.java
@@ -212,9 +212,8 @@ public class AggregateManagerImpl implements AggregateManager {
      * @return the default config
      */
     public static VaultFsConfig getDefaultConfig() {
-        try {
-            InputStream in = AggregateManagerImpl.class.getClassLoader()
-                    .getResourceAsStream(DEFAULT_CONFIG);
+        try (InputStream in = AggregateManagerImpl.class.getClassLoader()
+                    .getResourceAsStream(DEFAULT_CONFIG)) {
             if (in == null) {
                 throw new InternalError("Default config not in classpath: " + DEFAULT_CONFIG);
             }
@@ -231,9 +230,8 @@ public class AggregateManagerImpl implements AggregateManager {
      * @return the default config
      */
     public static VaultFsConfig getDefaultBinaryReferencesConfig() {
-        try {
-            InputStream in = AggregateManagerImpl.class.getClassLoader()
-                    .getResourceAsStream(DEFAULT_BINARY_REFERENCES_CONFIG);
+        try (InputStream in = AggregateManagerImpl.class.getClassLoader()
+                    .getResourceAsStream(DEFAULT_BINARY_REFERENCES_CONFIG)) {
             if (in == null) {
                 throw new InternalError("Default config not in classpath: " + DEFAULT_BINARY_REFERENCES_CONFIG);
             }
@@ -250,9 +248,8 @@ public class AggregateManagerImpl implements AggregateManager {
      * @return the default workspace filter
      */
     public static DefaultWorkspaceFilter getDefaultWorkspaceFilter() {
-        try {
-            InputStream in = AggregateManagerImpl.class.getClassLoader()
-                    .getResourceAsStream(DEFAULT_WSP_FILTER);
+        try (InputStream in = AggregateManagerImpl.class.getClassLoader()
+                    .getResourceAsStream(DEFAULT_WSP_FILTER)) {
             if (in == null) {
                 throw new InternalError("Default filter not in classpath: " + DEFAULT_WSP_FILTER);
             }
@@ -437,17 +434,15 @@ public class AggregateManagerImpl implements AggregateManager {
         } catch (RepositoryException e) {
             // ignore
         }
-        InputStream in = getClass().getClassLoader()
-                .getResourceAsStream(DEFAULT_NODETYPES);
-        try {
+        
+        try (InputStream in = getClass().getClassLoader()
+                .getResourceAsStream(DEFAULT_NODETYPES)) {
             NodeTypeInstaller installer = ServiceProviderFactory.getProvider().getDefaultNodeTypeInstaller(session);
             CNDReader types = ServiceProviderFactory.getProvider().getCNDReader();
             types.read(new InputStreamReader(in, "utf8"), DEFAULT_NODETYPES, null);
             installer.install(null, types);
         } catch (Exception e) {
             throw new RepositoryException("Error while importing nodetypes.", e);
-        } finally {
-            IOUtils.closeQuietly(in);
         }
     }
 

--- a/vault-core/src/main/java/org/apache/jackrabbit/vault/fs/impl/VaultFileOutputImpl.java
+++ b/vault-core/src/main/java/org/apache/jackrabbit/vault/fs/impl/VaultFileOutputImpl.java
@@ -30,7 +30,7 @@ import org.apache.jackrabbit.vault.util.FileInputSource;
 
 /**
  * Provides methods for writing jcr files. This can either be done by providing
- * an input source or by fetching an output stream. this output stream can be
+ * an input source or by fetching an output stream. This output stream can be
  * acquired via a {@link TransactionImpl}.
  *
  */
@@ -53,6 +53,10 @@ public class VaultFileOutputImpl implements VaultFileOutput {
         this.is = input;
     }
 
+    /**
+     * This method can only be called once.
+     * @return the returned output stream is implicitly closed via {@link #close()} and doesn't need to be closed.
+     */
     public OutputStream getOutputStream() throws IOException {
         if (out != null) {
             throw new IOException("Output stream already obtained.");

--- a/vault-core/src/main/java/org/apache/jackrabbit/vault/fs/impl/io/CNDSerializer.java
+++ b/vault-core/src/main/java/org/apache/jackrabbit/vault/fs/impl/io/CNDSerializer.java
@@ -27,6 +27,7 @@ import javax.jcr.NodeIterator;
 import javax.jcr.RepositoryException;
 import javax.jcr.Value;
 
+import org.apache.commons.io.output.CloseShieldOutputStream;
 import org.apache.jackrabbit.vault.fs.api.Aggregate;
 import org.apache.jackrabbit.vault.fs.api.SerializationType;
 import org.apache.jackrabbit.vault.fs.io.Serializer;
@@ -60,18 +61,18 @@ public class CNDSerializer implements Serializer {
      * {@inheritDoc}
      */
     public void writeContent(OutputStream out) throws IOException, RepositoryException {
-        Writer w = new OutputStreamWriter(out, "utf-8");
-        for (String prefix: aggregate.getNamespacePrefixes()) {
-            w.write("<'");
-            w.write(prefix);
-            w.write("'='");
-            w.write(escape(aggregate.getNamespaceURI(prefix)));
-            w.write("'>\n");
+        try (Writer w = new OutputStreamWriter(new CloseShieldOutputStream(out), "utf-8")) {
+            for (String prefix: aggregate.getNamespacePrefixes()) {
+                w.write("<'");
+                w.write(prefix);
+                w.write("'='");
+                w.write(escape(aggregate.getNamespaceURI(prefix)));
+                w.write("'>\n");
+            }
+            w.write("\n");
+            
+            writeNodeTypeDef(w, aggregate.getNode());
         }
-        w.write("\n");
-        
-        writeNodeTypeDef(w, aggregate.getNode());
-        w.close();
         out.flush();
     }
 

--- a/vault-core/src/main/java/org/apache/jackrabbit/vault/fs/impl/io/CompressionUtil.java
+++ b/vault-core/src/main/java/org/apache/jackrabbit/vault/fs/impl/io/CompressionUtil.java
@@ -155,15 +155,11 @@ public final class CompressionUtil {
     }
 
     static int seemsCompressible(@Nonnull Artifact artifact) {
-        InputStream stream = null;
-        try {
-            stream = artifact.getInputStream();
+        try (InputStream stream = artifact.getInputStream()) {
             byte[] sample = IOUtils.toByteArray(stream, SAMPLE_LENGTH);
             return isCompressible(sample, SAMPLE_LENGTH) ? 1 : -1;
         } catch (RepositoryException | IOException e) {
             log.warn(e.getMessage(), e);
-        } finally {
-            IOUtils.closeQuietly(stream);
         }
         return 0;
     }

--- a/vault-core/src/main/java/org/apache/jackrabbit/vault/fs/impl/io/NodeTypeArtifactHandler.java
+++ b/vault-core/src/main/java/org/apache/jackrabbit/vault/fs/impl/io/NodeTypeArtifactHandler.java
@@ -65,12 +65,9 @@ public class NodeTypeArtifactHandler extends AbstractArtifactHandler {
         }
         // do import
         CNDImporter importer = new CNDImporter();
-        InputStream in = primary.getInputStream();
-        try {
+        try (InputStream in = primary.getInputStream()) {
             Reader r = new InputStreamReader(in, "utf-8");
             return importer.doImport(parent, primary.getRelativePath(), r, primary.getRelativePath());
-        } finally {
-            in.close();
         }
     }
 

--- a/vault-core/src/main/java/org/apache/jackrabbit/vault/fs/io/AbstractExporter.java
+++ b/vault-core/src/main/java/org/apache/jackrabbit/vault/fs/io/AbstractExporter.java
@@ -66,7 +66,7 @@ import static org.apache.jackrabbit.vault.packaging.PackageProperties.NAME_VERSI
  * Generic context for exporters
  *
  */
-public abstract class AbstractExporter {
+public abstract class AbstractExporter implements AutoCloseable {
 
     /**
      * default logger
@@ -418,6 +418,12 @@ public abstract class AbstractExporter {
     public abstract void createDirectory(VaultFile file, String relPath)
             throws RepositoryException, IOException;
 
+    /**
+     * <p>The specified stream remains open after this method returns.
+     * @param in
+     * @param relPath
+     * @throws IOException
+     */
     public abstract void writeFile(InputStream in, String relPath)
             throws IOException;
 

--- a/vault-core/src/main/java/org/apache/jackrabbit/vault/fs/io/Importer.java
+++ b/vault-core/src/main/java/org/apache/jackrabbit/vault/fs/io/Importer.java
@@ -709,8 +709,7 @@ public class Importer {
                 } else if (".cnd".equals(ext)) {
                     if (opts.getCndPattern().matcher(repoPath).matches()) {
                         InputStream in = is.getByteStream();
-                        try {
-                            Reader r = new InputStreamReader(in, "utf8");
+                        try (Reader r = new InputStreamReader(in, "utf8")) {
                             CNDReader reader = ServiceProviderFactory.getProvider().getCNDReader();
                             // provide session namespaces
                             reader.read(r, is.getSystemId(), new NamespaceMapping(resolver));
@@ -718,8 +717,6 @@ public class Importer {
                             log.debug("Loaded nodetypes from {}.", repoPath);
                         } catch (IOException e1) {
                             log.error("Error while reading CND.", e1);
-                        } finally {
-                            IOUtils.closeQuietly(in);
                         }
                     }
                     ext = "";
@@ -1083,17 +1080,11 @@ public class Importer {
                 log.debug("Dry run: Would copy patch {} to {}", name, target.getPath());
             } else {
                 log.debug("Copying patch {} to {}", name, target.getPath());
-                InputStream in = null;
-                OutputStream out = null;
-                try {
-                    in = archive.getInputSource(e).getByteStream();
-                    out = FileUtils.openOutputStream(target);
+                try (InputStream in = archive.getInputSource(e).getByteStream();
+                     OutputStream out = FileUtils.openOutputStream(target)) {
                     IOUtils.copy(in, out);
                 } catch (IOException e1) {
                     log.error("Error while copying patch.", e);
-                } finally {
-                    IOUtils.closeQuietly(in);
-                    IOUtils.closeQuietly(out);
                 }
             }
             track("P", name);

--- a/vault-core/src/main/java/org/apache/jackrabbit/vault/fs/io/JarExporter.java
+++ b/vault-core/src/main/java/org/apache/jackrabbit/vault/fs/io/JarExporter.java
@@ -181,15 +181,13 @@ public class JarExporter extends AbstractExporter {
                 throw new RepositoryException("Artifact has no content.");
 
             case SPOOL:
-                OutputStream nout = new CloseShieldOutputStream(jOut);
-                a.spool(nout);
+                a.spool(jOut);
                 break;
 
             case STREAM:
-                nout = new CloseShieldOutputStream(jOut);
-                InputStream in = a.getInputStream();
-                IOUtils.copy(in, nout);
-                in.close();
+                try (InputStream in = a.getInputStream()) {
+                    IOUtils.copy(in, jOut);
+                }
                 break;
         }
         jOut.closeEntry();
@@ -203,9 +201,7 @@ public class JarExporter extends AbstractExporter {
         ZipEntry e = new ZipEntry(relPath);
         exportInfo.update(ExportInfo.Type.ADD, e.getName());
         jOut.putNextEntry(e);
-        OutputStream nout = new CloseShieldOutputStream(jOut);
-        IOUtils.copy(in, nout);
-        in.close();
+        IOUtils.copy(in, jOut);
         jOut.closeEntry();
     }
 
@@ -222,9 +218,9 @@ public class JarExporter extends AbstractExporter {
         jOut.putNextEntry(copy);
         if (!entry.isDirectory()) {
             // copy
-            InputStream in = zip.getInputStream(entry);
-            IOUtils.copy(in, jOut);
-            in.close();
+            try (InputStream in = zip.getInputStream(entry)) {
+                IOUtils.copy(in, jOut);
+            }
         }
         jOut.closeEntry();
         if (changeCompressionLevel) {

--- a/vault-core/src/main/java/org/apache/jackrabbit/vault/fs/io/JcrArchive.java
+++ b/vault-core/src/main/java/org/apache/jackrabbit/vault/fs/io/JcrArchive.java
@@ -129,7 +129,9 @@ public class JcrArchive extends AbstractArchive {
         // filter
         for (Entry entry: dir.getChildren()) {
             VaultInputSource src = getInputSource(entry);
-            inf.load(src.getByteStream(), src.getSystemId());
+            try (InputStream input = src.getByteStream()) {
+                inf.load(input, src.getSystemId());
+            }
         }
         if (inf.getFilter() == null) {
             log.debug("Archive {} does not contain filter definition.", this);

--- a/vault-core/src/main/java/org/apache/jackrabbit/vault/fs/io/JcrExporter.java
+++ b/vault-core/src/main/java/org/apache/jackrabbit/vault/fs/io/JcrExporter.java
@@ -133,11 +133,11 @@ public class JcrExporter extends AbstractExporter {
             case SPOOL:
                 // we can't support spool
             case STREAM:
-                InputStream in = a.getInputStream();
-                Binary b = content.getSession().getValueFactory().createBinary(in);
-                content.setProperty(JcrConstants.JCR_DATA, b);
-                b.dispose();
-                in.close();
+                try (InputStream in = a.getInputStream()) {
+                    Binary b = content.getSession().getValueFactory().createBinary(in);
+                    content.setProperty(JcrConstants.JCR_DATA, b);
+                    b.dispose();
+                }
                 break;
         }
         Calendar now = Calendar.getInstance();

--- a/vault-core/src/main/java/org/apache/jackrabbit/vault/fs/io/PlatformExporter.java
+++ b/vault-core/src/main/java/org/apache/jackrabbit/vault/fs/io/PlatformExporter.java
@@ -141,17 +141,16 @@ public class PlatformExporter extends AbstractExporter {
                 throw new RepositoryException("Artifact has no content.");
 
             case SPOOL:
-                FileOutputStream out = new FileOutputStream(local);
-                a.spool(out);
-                out.close();
+                try (FileOutputStream out = new FileOutputStream(local)) {
+                    a.spool(out);
+                }
                 break;
 
             case STREAM:
-                InputStream in = a.getInputStream();
-                out = new FileOutputStream(local);
-                IOUtils.copy(in, out);
-                in.close();
-                out.close();
+                try (InputStream in = a.getInputStream();
+                     OutputStream out = new FileOutputStream(local)) {
+                    IOUtils.copy(in, out);
+                }
                 break;
         }
         if (a.getLastModified() >= 0) {

--- a/vault-core/src/main/java/org/apache/jackrabbit/vault/fs/io/Serializer.java
+++ b/vault-core/src/main/java/org/apache/jackrabbit/vault/fs/io/Serializer.java
@@ -30,6 +30,12 @@ import org.apache.jackrabbit.vault.fs.api.SerializationType;
  */
 public interface Serializer {
 
+    /**
+     * <p>The specified stream remains open after this method returns.
+     * @param out
+     * @throws IOException
+     * @throws RepositoryException
+     */
     void writeContent(@Nonnull OutputStream out) throws IOException, RepositoryException;
 
     @Nonnull

--- a/vault-core/src/main/java/org/apache/jackrabbit/vault/fs/io/ZipArchive.java
+++ b/vault-core/src/main/java/org/apache/jackrabbit/vault/fs/io/ZipArchive.java
@@ -110,8 +110,8 @@ public class ZipArchive extends AbstractArchive {
             String path = entry.getName();
             // check for meta inf
             if (path.startsWith(Constants.META_DIR + "/")) {
-                try {
-                    inf.load(jar.getInputStream(entry), file.getPath() + ":" + path);
+                try (InputStream input = jar.getInputStream(entry)) {
+                    inf.load(input, file.getPath() + ":" + path);
                 } catch (ConfigurationException e1) {
                     throw new IOException(e1);
                 }

--- a/vault-core/src/main/java/org/apache/jackrabbit/vault/fs/io/ZipStreamArchive.java
+++ b/vault-core/src/main/java/org/apache/jackrabbit/vault/fs/io/ZipStreamArchive.java
@@ -106,7 +106,7 @@ public class ZipStreamArchive extends AbstractArchive {
     private final byte[] buffer = new byte[0x10000];
 
     /**
-     * Creates an ew zip stream archive on the given input stream.
+     * Creates a new zip stream archive on the given input stream.
      * @param in the input stream to read from.
      */
     public ZipStreamArchive(@Nonnull InputStream in) {
@@ -273,6 +273,9 @@ public class ZipStreamArchive extends AbstractArchive {
 
     @Override
     public void close() {
+        if (in != null) {
+            IOUtils.closeQuietly(in);
+        }
         if (raf != null) {
             try {
                 raf.close();

--- a/vault-core/src/main/java/org/apache/jackrabbit/vault/packaging/PackageManager.java
+++ b/vault-core/src/main/java/org/apache/jackrabbit/vault/packaging/PackageManager.java
@@ -108,7 +108,7 @@ public interface PackageManager {
     /**
      * Assembles a package using the given meta information. The package
      * is directly streamed to the given output stream.
-     *
+     * <p>The specified stream is closed after this method returns.
      * @param s the repository session
      * @param opts the export options
      * @param out the output stream to write to
@@ -138,6 +138,7 @@ public interface PackageManager {
     /**
      * Re-wraps the given package with the definition provided in the export
      * options.
+     * <p>The specified stream is closed after this method returns.
      * @param opts export options
      * @param src source package
      * @param out destination output stream

--- a/vault-core/src/main/java/org/apache/jackrabbit/vault/packaging/VaultPackage.java
+++ b/vault-core/src/main/java/org/apache/jackrabbit/vault/packaging/VaultPackage.java
@@ -93,12 +93,15 @@ public interface VaultPackage extends PackageProperties, AutoCloseable {
     File getFile();
 
     /**
-     * Closes this package and releases underlying data.
+     * Closes this package and releases underlying data. 
+     * This will also close the underlying {@link Archive} if it has been opened.
      */
     void close();
 
     /**
-     * Returns the underlying package archive
+     * Returns the underlying package archive.
+     * This does not need to be closed explicitly but rather is implicitly closed via
+     * a call to {@link #close()}.
      * @return the archive or {@code null} if already closed
      */
     Archive getArchive();

--- a/vault-core/src/main/java/org/apache/jackrabbit/vault/packaging/impl/InstallHookProcessorImpl.java
+++ b/vault-core/src/main/java/org/apache/jackrabbit/vault/packaging/impl/InstallHookProcessorImpl.java
@@ -108,17 +108,12 @@ public class InstallHookProcessorImpl implements InstallHookProcessor {
         File jarFile = File.createTempFile("vaulthook", ".jar");
         Hook hook = new Hook(input.getSystemId(), jarFile, classLoader);
 
-        OutputStream out = null;
-        InputStream in = input.getByteStream();
-        try {
-            out = FileUtils.openOutputStream(jarFile);
+        try (OutputStream out = FileUtils.openOutputStream(jarFile);
+             InputStream in = input.getByteStream()) {
             IOUtils.copy(in, out);
         } catch (IOException e) {
             hook.destroy();
             throw e;
-        } finally {
-            IOUtils.closeQuietly(in);
-            IOUtils.closeQuietly(out);
         }
         initHook(hook);
     }

--- a/vault-core/src/main/java/org/apache/jackrabbit/vault/util/InputStreamPump.java
+++ b/vault-core/src/main/java/org/apache/jackrabbit/vault/util/InputStreamPump.java
@@ -68,6 +68,11 @@ public class InputStreamPump extends InputStream {
     }
 
     public interface Pump {
+        /**
+         * <p>The specified stream remains open after this method returns.
+         * @param in
+         * @throws Exception
+         */
         void run(InputStream in) throws Exception;
     }
 

--- a/vault-core/src/main/java/org/apache/jackrabbit/vault/util/MD5.java
+++ b/vault-core/src/main/java/org/apache/jackrabbit/vault/util/MD5.java
@@ -76,26 +76,24 @@ public class MD5 {
     }
 
     public static MD5 digest(InputStream in) throws IOException {
+        MessageDigest md;
         try {
-            MessageDigest md;
-            try {
-                md = MessageDigest.getInstance("md5");
-            } catch (NoSuchAlgorithmException e) {
-                throw new IllegalArgumentException(e.toString());
-            }
-            byte[] buffer = new byte[8192];
-            int read;
-            while ((read = in.read(buffer)) > 0) {
-                md.update(buffer, 0, read);
-            }
-            return new MD5(md.digest());
-        } finally {
-            in.close();
+            md = MessageDigest.getInstance("md5");
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalArgumentException(e.toString());
         }
+        byte[] buffer = new byte[8192];
+        int read;
+        while ((read = in.read(buffer)) > 0) {
+            md.update(buffer, 0, read);
+        }
+        return new MD5(md.digest());
     }
 
     public static MD5 digest(File file) throws IOException {
-        return digest(new FileInputStream(file));
+        try (InputStream input = new FileInputStream(file)) {
+            return digest(input);
+        }
     }
 
     public String toString() {

--- a/vault-core/src/main/java/org/apache/jackrabbit/vault/util/SHA1.java
+++ b/vault-core/src/main/java/org/apache/jackrabbit/vault/util/SHA1.java
@@ -87,26 +87,24 @@ public class SHA1 {
     }
 
     public static SHA1 digest(InputStream in) throws IOException {
+        MessageDigest md;
         try {
-            MessageDigest md;
-            try {
-                md = MessageDigest.getInstance("SHA-1");
-            } catch (NoSuchAlgorithmException e) {
-                throw new IllegalArgumentException(e.toString());
-            }
-            byte[] buffer = new byte[8192];
-            int read;
-            while ((read = in.read(buffer)) > 0) {
-                md.update(buffer, 0, read);
-            }
-            return new SHA1(md.digest());
-        } finally {
-            in.close();
+            md = MessageDigest.getInstance("SHA-1");
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalArgumentException(e.toString());
         }
+        byte[] buffer = new byte[8192];
+        int read;
+        while ((read = in.read(buffer)) > 0) {
+            md.update(buffer, 0, read);
+        }
+        return new SHA1(md.digest());
     }
 
     public static SHA1 digest(File file) throws IOException {
-        return digest(FileUtils.openInputStream(file));
+        try (InputStream input = FileUtils.openInputStream(file)) {
+            return digest(input);
+        }
     }
 
     public String toString() {

--- a/vault-core/src/main/java/org/apache/jackrabbit/vault/util/xml/serialize/BaseMarkupSerializer.java
+++ b/vault-core/src/main/java/org/apache/jackrabbit/vault/util/xml/serialize/BaseMarkupSerializer.java
@@ -275,7 +275,9 @@ public abstract class BaseMarkupSerializer
         return this;
     }
 
-
+    /**
+     * <p>The specified stream will not be closed by this class.
+     */
     public void setOutputByteStream(OutputStream output) {
         if (output == null) {
             String msg = DOMMessageFormatter.formatMessage(DOMMessageFormatter.SERIALIZER_DOMAIN,
@@ -288,6 +290,9 @@ public abstract class BaseMarkupSerializer
     }
 
 
+    /**
+     * <p>The specified writer will not be closed by this class.
+     */
     public void setOutputCharStream(Writer writer) {
         if (writer == null) {
             String msg = DOMMessageFormatter.formatMessage(DOMMessageFormatter.SERIALIZER_DOMAIN,

--- a/vault-core/src/main/java/org/apache/jackrabbit/vault/util/xml/serialize/XMLSerializer.java
+++ b/vault-core/src/main/java/org/apache/jackrabbit/vault/util/xml/serialize/XMLSerializer.java
@@ -175,8 +175,11 @@ public class XMLSerializer extends BaseMarkupSerializer {
      * using the specified output format. If <tt>format</tt> is null,
      * will use a default output format.
      *
+     * <p>The specified writer will not be closed by this class.
+     * 
      * @param writer The writer to use
      * @param format The output format to use, null for the default
+     * 
      */
     public XMLSerializer(Writer writer, OutputFormat format) {
         super(format != null ? format : new OutputFormat(Method.XML, null, false));
@@ -189,7 +192,8 @@ public class XMLSerializer extends BaseMarkupSerializer {
      * Constructs a new serializer that writes to the specified output
      * stream using the specified output format. If <tt>format</tt>
      * is null, will use a default output format.
-     *
+     * <p>The specified stream will not be closed by this class.
+     * 
      * @param output The output stream to use
      * @param format The output format to use, null for the default
      */

--- a/vault-core/src/test/java/org/apache/jackrabbit/vault/packaging/integration/TestSpecialDoubleProperties.java
+++ b/vault-core/src/test/java/org/apache/jackrabbit/vault/packaging/integration/TestSpecialDoubleProperties.java
@@ -72,20 +72,21 @@ public class TestSpecialDoubleProperties extends IntegrationTestBase {
 
         Archive.Entry e = pkg.getArchive().getEntry("jcr_root/tmp/.content.xml");
         InputSource is = pkg.getArchive().getInputSource(e);
-        Reader r = new InputStreamReader(is.getByteStream(), "utf-8");
-        String contentXml = IOUtils.toString(r);
+        try (Reader r = new InputStreamReader(is.getByteStream(), "utf-8")) {
+            String contentXml = IOUtils.toString(r);
 
-        assertEquals("Serialized content",
-                "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
-                        "<jcr:root xmlns:jcr=\"http://www.jcp.org/jcr/1.0\" xmlns:nt=\"http://www.jcp.org/jcr/nt/1.0\"\n" +
-                        "    jcr:primaryType=\"nt:unstructured\">\n" +
-                        "    <jcr:content\n" +
-                        "        jcr:primaryType=\"nt:unstructured\"\n" +
-                        "        double_nan=\"{Double}NaN\"\n" +
-                        "        double_neg_inf=\"{Double}-Infinity\"\n" +
-                        "        double_pos_inf=\"{Double}Infinity\"/>\n" +
-                        "</jcr:root>\n",
-                contentXml);
+            assertEquals("Serialized content",
+                    "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+                            "<jcr:root xmlns:jcr=\"http://www.jcp.org/jcr/1.0\" xmlns:nt=\"http://www.jcp.org/jcr/nt/1.0\"\n" +
+                            "    jcr:primaryType=\"nt:unstructured\">\n" +
+                            "    <jcr:content\n" +
+                            "        jcr:primaryType=\"nt:unstructured\"\n" +
+                            "        double_nan=\"{Double}NaN\"\n" +
+                            "        double_neg_inf=\"{Double}-Infinity\"\n" +
+                            "        double_pos_inf=\"{Double}Infinity\"/>\n" +
+                            "</jcr:root>\n",
+                    contentXml);
+        }
         pkg.close();
         tmpFile.delete();
     }

--- a/vault-core/src/test/java/org/apache/jackrabbit/vault/packaging/integration/TestSubPackages.java
+++ b/vault-core/src/test/java/org/apache/jackrabbit/vault/packaging/integration/TestSubPackages.java
@@ -674,61 +674,62 @@ public class TestSubPackages extends IntegrationTestBase {
         JcrPackage pkg = packMgr.open(PACKAGE_ID_SUB_TEST);
         packMgr.assemble(pkg, new DefaultProgressListener());
 
-        ZipInputStream in = new ZipInputStream(pkg.getData().getBinary().getStream());
-        ZipEntry e;
-        List<String> entries = new ArrayList<>();
-        String filter = "";
-        while ((e = in.getNextEntry()) != null) {
-            entries.add(e.getName());
-            if ("META-INF/vault/filter.xml".equals(e.getName())) {
-                filter = IOUtils.toString(in, "utf-8");
+        try (ZipInputStream in = new ZipInputStream(pkg.getData().getBinary().getStream())) {
+            ZipEntry e;
+            List<String> entries = new ArrayList<>();
+            String filter = "";
+            while ((e = in.getNextEntry()) != null) {
+                entries.add(e.getName());
+                if ("META-INF/vault/filter.xml".equals(e.getName())) {
+                    filter = IOUtils.toString(in, "utf-8");
+                }
             }
-        }
-        in.close();
-        Collections.sort(entries);
-        StringBuffer result = new StringBuffer();
-        for (String name: entries) {
-            // exclude some of the entries that depend on the repository setup
-            if ("jcr_root/etc/.content.xml".equals(name)
-                    || "jcr_root/etc/packages/my_packages/.content.xml".equals(name)
-                    || "jcr_root/etc/packages/.content.xml".equals(name)) {
-                continue;
+            Collections.sort(entries);
+            StringBuffer result = new StringBuffer();
+            for (String name: entries) {
+                // exclude some of the entries that depend on the repository setup
+                if ("jcr_root/etc/.content.xml".equals(name)
+                        || "jcr_root/etc/packages/my_packages/.content.xml".equals(name)
+                        || "jcr_root/etc/packages/.content.xml".equals(name)) {
+                    continue;
+                }
+                result.append(name).append("\n");
             }
-            result.append(name).append("\n");
+        
+            assertEquals("Filter must be correct",
+                    "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+                    "<workspaceFilter version=\"1.0\">\n" +
+                    "    <filter root=\"/etc/packages/my_packages/sub_a.zip\"/>\n" +
+                    "    <filter root=\"/etc/packages/my_packages/sub_b.zip\"/>\n" +
+                    "</workspaceFilter>\n", filter);
+    
+            assertEquals("Package must contain proper entries.",
+                    "META-INF/\n" +
+                    "META-INF/MANIFEST.MF\n" +
+                    "META-INF/vault/\n" +
+                    "META-INF/vault/config.xml\n" +
+                    "META-INF/vault/definition/\n" +
+                    "META-INF/vault/definition/.content.xml\n" +
+                    "META-INF/vault/filter.xml\n" +
+                    "META-INF/vault/nodetypes.cnd\n" +
+                    "META-INF/vault/properties.xml\n" +
+                    "jcr_root/.content.xml\n" +
+                    "jcr_root/etc/\n" +
+                    "jcr_root/etc/packages/\n" +
+                    "jcr_root/etc/packages/my_packages/\n" +
+                    "jcr_root/etc/packages/my_packages/sub_a.zip\n" +
+                    "jcr_root/etc/packages/my_packages/sub_a.zip.dir/\n" +
+                    "jcr_root/etc/packages/my_packages/sub_a.zip.dir/.content.xml\n" +
+                    "jcr_root/etc/packages/my_packages/sub_a.zip.dir/_jcr_content/\n" +
+                    "jcr_root/etc/packages/my_packages/sub_a.zip.dir/_jcr_content/_vlt_definition/\n" +
+                    "jcr_root/etc/packages/my_packages/sub_a.zip.dir/_jcr_content/_vlt_definition/.content.xml\n" +
+                    "jcr_root/etc/packages/my_packages/sub_b.zip\n" +
+                    "jcr_root/etc/packages/my_packages/sub_b.zip.dir/\n" +
+                    "jcr_root/etc/packages/my_packages/sub_b.zip.dir/.content.xml\n" +
+                    "jcr_root/etc/packages/my_packages/sub_b.zip.dir/_jcr_content/\n" +
+                    "jcr_root/etc/packages/my_packages/sub_b.zip.dir/_jcr_content/_vlt_definition/\n" +
+                    "jcr_root/etc/packages/my_packages/sub_b.zip.dir/_jcr_content/_vlt_definition/.content.xml\n", result.toString());
         }
-        assertEquals("Filter must be correct",
-                "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
-                "<workspaceFilter version=\"1.0\">\n" +
-                "    <filter root=\"/etc/packages/my_packages/sub_a.zip\"/>\n" +
-                "    <filter root=\"/etc/packages/my_packages/sub_b.zip\"/>\n" +
-                "</workspaceFilter>\n", filter);
-
-        assertEquals("Package must contain proper entries.",
-                "META-INF/\n" +
-                "META-INF/MANIFEST.MF\n" +
-                "META-INF/vault/\n" +
-                "META-INF/vault/config.xml\n" +
-                "META-INF/vault/definition/\n" +
-                "META-INF/vault/definition/.content.xml\n" +
-                "META-INF/vault/filter.xml\n" +
-                "META-INF/vault/nodetypes.cnd\n" +
-                "META-INF/vault/properties.xml\n" +
-                "jcr_root/.content.xml\n" +
-                "jcr_root/etc/\n" +
-                "jcr_root/etc/packages/\n" +
-                "jcr_root/etc/packages/my_packages/\n" +
-                "jcr_root/etc/packages/my_packages/sub_a.zip\n" +
-                "jcr_root/etc/packages/my_packages/sub_a.zip.dir/\n" +
-                "jcr_root/etc/packages/my_packages/sub_a.zip.dir/.content.xml\n" +
-                "jcr_root/etc/packages/my_packages/sub_a.zip.dir/_jcr_content/\n" +
-                "jcr_root/etc/packages/my_packages/sub_a.zip.dir/_jcr_content/_vlt_definition/\n" +
-                "jcr_root/etc/packages/my_packages/sub_a.zip.dir/_jcr_content/_vlt_definition/.content.xml\n" +
-                "jcr_root/etc/packages/my_packages/sub_b.zip\n" +
-                "jcr_root/etc/packages/my_packages/sub_b.zip.dir/\n" +
-                "jcr_root/etc/packages/my_packages/sub_b.zip.dir/.content.xml\n" +
-                "jcr_root/etc/packages/my_packages/sub_b.zip.dir/_jcr_content/\n" +
-                "jcr_root/etc/packages/my_packages/sub_b.zip.dir/_jcr_content/_vlt_definition/\n" +
-                "jcr_root/etc/packages/my_packages/sub_b.zip.dir/_jcr_content/_vlt_definition/.content.xml\n", result.toString());
     }
 
     /**

--- a/vault-core/src/test/java/org/apache/jackrabbit/vault/packaging/registry/impl/FSRegisteredPackageTest.java
+++ b/vault-core/src/test/java/org/apache/jackrabbit/vault/packaging/registry/impl/FSRegisteredPackageTest.java
@@ -42,12 +42,11 @@ public class FSRegisteredPackageTest {
     private static final PackageId DUMMY_ID = new PackageId("someGroup", "someName", "someVersion");
 
     private File getTempFile(String name) throws IOException {
-        InputStream in = getClass().getResourceAsStream(name);
         File tmpFile = File.createTempFile("vaultpack", ".zip");
-        FileOutputStream out = FileUtils.openOutputStream(tmpFile);
-        IOUtils.copy(in, out);
-        in.close();
-        out.close();
+        try (InputStream in = getClass().getResourceAsStream(name);
+             FileOutputStream out = FileUtils.openOutputStream(tmpFile)) {
+            IOUtils.copy(in, out);
+        }
         return tmpFile;
     }
 

--- a/vault-core/src/test/java/org/apache/jackrabbit/vault/util/MD5Test.java
+++ b/vault-core/src/test/java/org/apache/jackrabbit/vault/util/MD5Test.java
@@ -65,9 +65,10 @@ public class MD5Test extends TestCase {
 
 
     public void testDigest() throws IOException {
-        InputStream in = new ByteArrayInputStream(testData.getBytes());
-        MD5 md5 = MD5.digest(in);
-        assertEquals(testString, md5.toString());
+        try (InputStream in = new ByteArrayInputStream(testData.getBytes())) {
+            MD5 md5 = MD5.digest(in);
+            assertEquals(testString, md5.toString());
+        }
     }
 
     private void assertEquals(byte[] expected, byte[] result) {

--- a/vault-core/src/test/java/org/apache/jackrabbit/vault/util/SHA1Test.java
+++ b/vault-core/src/test/java/org/apache/jackrabbit/vault/util/SHA1Test.java
@@ -67,9 +67,10 @@ public class SHA1Test extends TestCase {
 
 
     public void testDigest() throws IOException {
-        InputStream in = new ByteArrayInputStream(testData.getBytes());
-        SHA1 sha1 = SHA1.digest(in);
-        assertEquals(testString, sha1.toString());
+        try (InputStream in = new ByteArrayInputStream(testData.getBytes())) {
+            SHA1 sha1 = SHA1.digest(in);
+            assertEquals(testString, sha1.toString());
+        }
     }
 
     private void assertEquals(byte[] expected, byte[] result) {


### PR DESCRIPTION
stream being passed to methods

The only remaining method which still closes a passed stream (given as
method argument) is PackageManager.assemble(...) and
PackageManager.rewrap(...)