### PR TITLE
Feature/enable insecure https host

### DIFF
--- a/vault-cli/src/main/java/org/apache/jackrabbit/vault/util/console/AbstractApplication.java
+++ b/vault-cli/src/main/java/org/apache/jackrabbit/vault/util/console/AbstractApplication.java
@@ -69,6 +69,7 @@ public abstract class AbstractApplication {
     private Option optLogLevel;
     private Option optVersion;
     private Option optHelp;
+    private Option optInsecureHttps;
 
     public String getVersion() {
         return getPomProperties().getVersion();
@@ -198,6 +199,17 @@ public abstract class AbstractApplication {
                         )
                         .create();
 
+        optInsecureHttps =
+                obuilder
+                        .withLongName("insecure")
+                        .withDescription("allow expired ssl certs for https")
+                        .withArgument(abuilder
+                                .withName("command")
+                                .withMaximum(1)
+                                .create()
+                        )
+                        .create();
+
         gbuilder
                 .withName("Global options:")
                 //.withOption(optPropertyFile)
@@ -206,6 +218,7 @@ public abstract class AbstractApplication {
                 .withOption(optVersion)
                 .withOption(optLogLevel)
                 .withOption(optHelp)
+                .withOption(optInsecureHttps)
                 .withMinimum(0);
         /*
         if (getConsole() != null) {

--- a/vault-core/src/main/java/org/apache/jackrabbit/vault/packaging/PackageId.java
+++ b/vault-core/src/main/java/org/apache/jackrabbit/vault/packaging/PackageId.java
@@ -209,7 +209,7 @@ public class PackageId implements Comparable<PackageId> {
     public PackageId(String group, String name, Version version) {
         fromPath = false;
         // validate group
-        if (group.equals(ETC_PACKAGES)) {
+        if (group == null || group.equals(ETC_PACKAGES)) {
             group = "";
         } else if (group.startsWith(ETC_PACKAGES_PREFIX)) {
             group = group.substring(ETC_PACKAGES_PREFIX.length());
@@ -217,6 +217,9 @@ public class PackageId implements Comparable<PackageId> {
             group = group.substring(1);
         }
         this.group = group;
+        if (name == null) {
+            name = "";
+        }
         this.name = name;
         this.version = version == null ? Version.EMPTY : version;
         this.str = getString(this.group, name, this.version);


### PR DESCRIPTION
Provides an --insecure cli argument.
Enabling optional support for expired ssl certs when using https. Was necessary to overcome an invalid cert on a clients development server.