### PR TITLE
JCRVLT-419: Feature/enable insecure https host

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -350,6 +350,16 @@
                 <artifactId>jackrabbit-webdav</artifactId>
                 <version>${jackrabbit.version}</version>
             </dependency>
+            <dependency>
+                <groupId>org.apache.jackrabbit</groupId>
+                <artifactId>jackrabbit-parent</artifactId>
+                <version>${jackrabbit.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.jackrabbit</groupId>
+                <artifactId>jackrabbit-data</artifactId>
+                <version>${jackrabbit.version}</version>
+            </dependency>
 
             <!-- JCR Stuff -->
             <dependency>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -350,16 +350,6 @@
                 <artifactId>jackrabbit-webdav</artifactId>
                 <version>${jackrabbit.version}</version>
             </dependency>
-            <dependency>
-                <groupId>org.apache.jackrabbit</groupId>
-                <artifactId>jackrabbit-parent</artifactId>
-                <version>${jackrabbit.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.jackrabbit</groupId>
-                <artifactId>jackrabbit-data</artifactId>
-                <version>${jackrabbit.version}</version>
-            </dependency>
 
             <!-- JCR Stuff -->
             <dependency>

--- a/vault-cli/src/main/java/org/apache/jackrabbit/vault/cli/CmdExportCli.java
+++ b/vault-cli/src/main/java/org/apache/jackrabbit/vault/cli/CmdExportCli.java
@@ -100,6 +100,7 @@ public class CmdExportCli extends AbstractVaultCommand {
         }
 
         vCtx.setVerbose(cl.hasOption(OPT_VERBOSE));
+        vCtx.setAllowInsecureHttps(cl.hasOption(OPT_INSECURE_HTTPS));
         VaultFile vaultFile = vCtx.getFileSystem(addr).getFile(jcrPath);
         if (vaultFile == null) {
             VaultFsApp.log.error("Not such remote file: {}", jcrPath);

--- a/vault-cli/src/main/java/org/apache/jackrabbit/vault/util/console/AbstractApplication.java
+++ b/vault-cli/src/main/java/org/apache/jackrabbit/vault/util/console/AbstractApplication.java
@@ -210,17 +210,6 @@ public abstract class AbstractApplication {
                         )
                         .create();
 
-        optInsecureHttps =
-                obuilder
-                        .withLongName("insecure")
-                        .withDescription("allow expired ssl certs for https")
-                        .withArgument(abuilder
-                                .withName("command")
-                                .withMaximum(1)
-                                .create()
-                        )
-                        .create();
-
         gbuilder
                 .withName("Global options:")
                 //.withOption(optPropertyFile)

--- a/vault-cli/src/main/java/org/apache/jackrabbit/vault/util/console/AbstractApplication.java
+++ b/vault-cli/src/main/java/org/apache/jackrabbit/vault/util/console/AbstractApplication.java
@@ -210,6 +210,17 @@ public abstract class AbstractApplication {
                         )
                         .create();
 
+        optInsecureHttps =
+                obuilder
+                        .withLongName("insecure")
+                        .withDescription("allow expired ssl certs for https")
+                        .withArgument(abuilder
+                                .withName("command")
+                                .withMaximum(1)
+                                .create()
+                        )
+                        .create();
+
         gbuilder
                 .withName("Global options:")
                 //.withOption(optPropertyFile)

--- a/vault-cli/src/main/java/org/apache/jackrabbit/vault/util/console/AbstractApplication.java
+++ b/vault-cli/src/main/java/org/apache/jackrabbit/vault/util/console/AbstractApplication.java
@@ -16,13 +16,6 @@
  */
 package org.apache.jackrabbit.vault.util.console;
 
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.util.Iterator;
-import java.util.Properties;
-
 import org.apache.commons.cli2.CommandLine;
 import org.apache.commons.cli2.DisplaySetting;
 import org.apache.commons.cli2.Group;
@@ -39,6 +32,13 @@ import org.apache.jackrabbit.vault.util.console.util.Log4JConfig;
 import org.apache.jackrabbit.vault.util.console.util.PomProperties;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.util.Iterator;
+import java.util.Properties;
 
 /**
  * {@code Console}...
@@ -69,6 +69,7 @@ public abstract class AbstractApplication {
     private Option optLogLevel;
     private Option optVersion;
     private Option optHelp;
+    private Option optInsecureHttps;
 
     public String getVersion() {
         return getPomProperties().getVersion();
@@ -77,11 +78,11 @@ public abstract class AbstractApplication {
     public PomProperties getPomProperties() {
         return new PomProperties("org.apache.jackrabbit.vault", "vault-cli");
     }
-    
+
     public String getCopyrightLine() {
         return "Copyright 2013 by Apache Software Foundation. See LICENSE.txt for more information.";
     }
-    
+
     public String getVersionString() {
         return getApplicationName() + " [version " + getVersion() + "] " + getCopyrightLine();
     }
@@ -198,6 +199,17 @@ public abstract class AbstractApplication {
                         )
                         .create();
 
+        optInsecureHttps =
+                obuilder
+                        .withLongName("insecure")
+                        .withDescription("allow expired ssl certs for https")
+                        .withArgument(abuilder
+                                .withName("command")
+                                .withMaximum(1)
+                                .create()
+                        )
+                        .create();
+
         gbuilder
                 .withName("Global options:")
                 //.withOption(optPropertyFile)
@@ -206,6 +218,7 @@ public abstract class AbstractApplication {
                 .withOption(optVersion)
                 .withOption(optLogLevel)
                 .withOption(optHelp)
+                .withOption(optInsecureHttps)
                 .withMinimum(0);
         /*
         if (getConsole() != null) {
@@ -290,7 +303,7 @@ public abstract class AbstractApplication {
                 // eg: vlt checkout --help
                 Iterator iter = cl.getOptions().iterator();
                 while (iter.hasNext()) {
-                    Object o = iter.next();                    
+                    Object o = iter.next();
                     if (o instanceof Command) {
                         cmd = ((Command) o).getPreferredName();
                         break;

--- a/vault-cli/src/main/java/org/apache/jackrabbit/vault/util/console/CliCommand.java
+++ b/vault-cli/src/main/java/org/apache/jackrabbit/vault/util/console/CliCommand.java
@@ -43,6 +43,12 @@ public interface CliCommand {
             .withDescription("print as little as possible")
             .create();
 
+    Option OPT_INSECURE_HTTPS = new DefaultOptionBuilder()
+            .withLongName("insecure")
+            .withDescription("allow expired ssl certs for https")
+            .create();
+
+
     boolean execute(ExecutionContext ctx, CommandLine cl) throws Exception;
 
     String getName();
@@ -56,5 +62,6 @@ public interface CliCommand {
     boolean hasName(String name);
 
     Option getCommand();
-    
+
+
 }

--- a/vault-core/pom.xml
+++ b/vault-core/pom.xml
@@ -148,7 +148,6 @@
             <artifactId>jcr</artifactId>
             <scope>provided</scope>
         </dependency>
-        
         <dependency>
             <groupId>org.osgi</groupId>
             <artifactId>org.osgi.core</artifactId>
@@ -202,6 +201,20 @@
             <version>2.0.4</version>
             <scope>provided</scope>
             <optional>true</optional>
+        </dependency>
+
+        <!-- apache -->
+        <dependency>
+            <groupId>commons-collections</groupId>
+            <artifactId>commons-collections</artifactId>
+            <version>3.2.2</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.tika</groupId>
+            <artifactId>tika-core</artifactId>
+            <version>1.22</version>
+            <scope>provided</scope>
         </dependency>
 
         <!-- test deps -->
@@ -289,7 +302,18 @@
             <version>2.6.0</version>
             <scope>test</scope>
         </dependency>
-
+        <dependency>
+            <groupId>concurrent</groupId>
+            <artifactId>concurrent</artifactId>
+            <version>1.3.4</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>trove</groupId>
+            <artifactId>trove</artifactId>
+            <version>1.0.2</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <!-- ====================================================================== -->

--- a/vault-core/pom.xml
+++ b/vault-core/pom.xml
@@ -217,6 +217,14 @@
             <scope>provided</scope>
         </dependency>
 
+        <!-- other -->
+        <dependency>
+            <groupId>org.jetbrains</groupId>
+            <artifactId>annotations</artifactId>
+            <version>16.0.1</version>
+            <scope>provided</scope>
+        </dependency>
+
         <!-- test deps -->
         <dependency>
             <groupId>junit</groupId>

--- a/vault-core/pom.xml
+++ b/vault-core/pom.xml
@@ -203,28 +203,6 @@
             <optional>true</optional>
         </dependency>
 
-        <!-- apache -->
-        <dependency>
-            <groupId>commons-collections</groupId>
-            <artifactId>commons-collections</artifactId>
-            <version>3.2.2</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.tika</groupId>
-            <artifactId>tika-core</artifactId>
-            <version>1.22</version>
-            <scope>provided</scope>
-        </dependency>
-
-        <!-- other -->
-        <dependency>
-            <groupId>org.jetbrains</groupId>
-            <artifactId>annotations</artifactId>
-            <version>16.0.1</version>
-            <scope>provided</scope>
-        </dependency>
-
         <!-- test deps -->
         <dependency>
             <groupId>junit</groupId>
@@ -310,18 +288,7 @@
             <version>2.6.0</version>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>concurrent</groupId>
-            <artifactId>concurrent</artifactId>
-            <version>1.3.4</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>trove</groupId>
-            <artifactId>trove</artifactId>
-            <version>1.0.2</version>
-            <scope>test</scope>
-        </dependency>
+
     </dependencies>
 
     <!-- ====================================================================== -->

--- a/vault-core/src/main/java/org/apache/jackrabbit/vault/fs/api/RepositoryFactory.java
+++ b/vault-core/src/main/java/org/apache/jackrabbit/vault/fs/api/RepositoryFactory.java
@@ -31,4 +31,7 @@ public interface RepositoryFactory {
 
     public Repository createRepository(RepositoryAddress address)
             throws RepositoryException;
+
+    public Repository createRepository(RepositoryAddress address, boolean allowInsecureHttps)
+            throws RepositoryException;
 }

--- a/vault-core/src/main/java/org/apache/jackrabbit/vault/packaging/PackageId.java
+++ b/vault-core/src/main/java/org/apache/jackrabbit/vault/packaging/PackageId.java
@@ -209,7 +209,7 @@ public class PackageId implements Comparable<PackageId> {
     public PackageId(String group, String name, Version version) {
         fromPath = false;
         // validate group
-        if (group == null || group.equals(ETC_PACKAGES)) {
+        if (group.equals(ETC_PACKAGES)) {
             group = "";
         } else if (group.startsWith(ETC_PACKAGES_PREFIX)) {
             group = group.substring(ETC_PACKAGES_PREFIX.length());

--- a/vault-core/src/main/java/org/apache/jackrabbit/vault/packaging/PackageId.java
+++ b/vault-core/src/main/java/org/apache/jackrabbit/vault/packaging/PackageId.java
@@ -217,8 +217,6 @@ public class PackageId implements Comparable<PackageId> {
             group = group.substring(1);
         }
         this.group = group;
-        if (name == null)
-            name = "";
         this.name = name;
         this.version = version == null ? Version.EMPTY : version;
         this.str = getString(this.group, name, this.version);

--- a/vault-core/src/main/java/org/apache/jackrabbit/vault/packaging/PackageId.java
+++ b/vault-core/src/main/java/org/apache/jackrabbit/vault/packaging/PackageId.java
@@ -43,7 +43,7 @@ public class PackageId implements Comparable<PackageId> {
     public static final String ETC_PACKAGES_PREFIX = "/etc/packages/";
 
     public static final PackageId[] EMPTY = new PackageId[0];
-    
+
     private final String group;
 
     private final String name;
@@ -209,7 +209,7 @@ public class PackageId implements Comparable<PackageId> {
     public PackageId(String group, String name, Version version) {
         fromPath = false;
         // validate group
-        if (group.equals(ETC_PACKAGES)) {
+        if (group == null || group.equals(ETC_PACKAGES)) {
             group = "";
         } else if (group.startsWith(ETC_PACKAGES_PREFIX)) {
             group = group.substring(ETC_PACKAGES_PREFIX.length());
@@ -217,6 +217,8 @@ public class PackageId implements Comparable<PackageId> {
             group = group.substring(1);
         }
         this.group = group;
+        if (name == null)
+            name = "";
         this.name = name;
         this.version = version == null ? Version.EMPTY : version;
         this.str = getString(this.group, name, this.version);
@@ -376,7 +378,7 @@ public class PackageId implements Comparable<PackageId> {
 
     /**
      * {@inheritDoc}
-     *  
+     *
      * Compares this id with the given one.
      */
     public int compareTo(PackageId o) {

--- a/vault-core/src/main/java/org/apache/jackrabbit/vault/util/RepositoryProvider.java
+++ b/vault-core/src/main/java/org/apache/jackrabbit/vault/util/RepositoryProvider.java
@@ -46,15 +46,23 @@ public class RepositoryProvider {
 
     public Repository getRepository(RepositoryAddress address)
             throws RepositoryException {
+        return this.getRepository(address, false);
+    }
+
+    public Repository getRepository(RepositoryAddress address, boolean allowInsecureHttps)
+            throws RepositoryException {
         Repository rep = repos.get(address);
         if (rep == null) {
-            rep = createRepository(address);
+            rep = createRepository(address, allowInsecureHttps);
             repos.put(address, rep);
         }
         return rep;
     }
-
     private Repository createRepository(RepositoryAddress address)
+            throws RepositoryException {
+        return this.createRepository(address, false);
+    }
+    private Repository createRepository(RepositoryAddress address, boolean allowInsecureHttps)
             throws RepositoryException {
         ServiceLoader<RepositoryFactory> loader = ServiceLoader.load(RepositoryFactory.class);
         Iterator<RepositoryFactory> iter = loader.iterator();
@@ -62,7 +70,7 @@ public class RepositoryProvider {
         while (iter.hasNext()) {
             RepositoryFactory fac = iter.next();
             supported.addAll(fac.getSupportedSchemes());
-            Repository rep = fac.createRepository(address);
+            Repository rep = fac.createRepository(address, allowInsecureHttps);
             if (rep != null) {
                 // wrap JCR logger
                 if (Boolean.getBoolean("jcrlog.sysout") || System.getProperty("jcrlog.file") != null) {

--- a/vault-davex/pom.xml
+++ b/vault-davex/pom.xml
@@ -63,6 +63,10 @@
         </dependency>
         <dependency>
             <groupId>org.apache.jackrabbit</groupId>
+            <artifactId>jackrabbit-spi</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.jackrabbit</groupId>
             <artifactId>jackrabbit-spi-commons</artifactId>
         </dependency>
         <dependency>
@@ -73,7 +77,7 @@
             <groupId>org.apache.jackrabbit</groupId>
             <artifactId>jackrabbit-spi2dav</artifactId>
         </dependency>
-        
+
         <!-- add some dependencies of spi2davex -->
         <dependency>
             <groupId>org.apache.jackrabbit</groupId>

--- a/vault-davex/pom.xml
+++ b/vault-davex/pom.xml
@@ -63,10 +63,6 @@
         </dependency>
         <dependency>
             <groupId>org.apache.jackrabbit</groupId>
-            <artifactId>jackrabbit-spi</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.jackrabbit</groupId>
             <artifactId>jackrabbit-spi-commons</artifactId>
         </dependency>
         <dependency>

--- a/vault-davex/src/main/java/org/apache/jackrabbit/vault/davex/DAVExRepositoryFactory.java
+++ b/vault-davex/src/main/java/org/apache/jackrabbit/vault/davex/DAVExRepositoryFactory.java
@@ -66,8 +66,11 @@ public class DAVExRepositoryFactory implements RepositoryFactory {
     public Set<String> getSupportedSchemes() {
         return SCHEMES;
     }
-
     public Repository createRepository(RepositoryAddress address)
+            throws RepositoryException {
+        return this.createRepository(address, false);
+    }
+    public Repository createRepository(RepositoryAddress address, boolean allowInsecureHttps)
             throws RepositoryException {
         if (!SCHEMES.contains(address.getSpecificURI().getScheme())) {
             return null;
@@ -105,6 +108,9 @@ public class DAVExRepositoryFactory implements RepositoryFactory {
             String workspace = address.getWorkspace();
             if (workspace != null) {
                 parameters.put(Spi2davexRepositoryServiceFactory.PARAM_WORKSPACE_NAME_DEFAULT, workspace);
+            }
+            if (allowInsecureHttps && uri.getScheme().equals("https")) {
+                parameters.put(Spi2davexRepositoryServiceFactory.PARAM_REPOSITORY_URI_INSECURE, true);
             }
             System.out.printf("Connecting via JCR remoting to %s%n", address.getSpecificURI().toString());
             return new RepositoryFactoryImpl().getRepository(parameters);

--- a/vault-validation/pom.xml
+++ b/vault-validation/pom.xml
@@ -101,7 +101,10 @@
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
         </dependency>
-
+        <dependency>
+            <groupId>org.apache.jackrabbit</groupId>
+            <artifactId>jackrabbit-spi</artifactId>
+        </dependency>
         <dependency>
             <groupId>org.apache.jackrabbit</groupId>
             <artifactId>jackrabbit-spi-commons</artifactId>
@@ -132,7 +135,7 @@
             <artifactId>osgi.annotation</artifactId>
             <scope>provided</scope>
         </dependency>
-            
+
         <!-- http://metainf-services.kohsuke.org/index.html -->
         <dependency>
             <groupId>org.kohsuke.metainf-services</groupId>

--- a/vault-validation/pom.xml
+++ b/vault-validation/pom.xml
@@ -103,10 +103,6 @@
         </dependency>
         <dependency>
             <groupId>org.apache.jackrabbit</groupId>
-            <artifactId>jackrabbit-spi</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.jackrabbit</groupId>
             <artifactId>jackrabbit-spi-commons</artifactId>
         </dependency>
 

--- a/vault-vlt/src/main/java/org/apache/jackrabbit/vault/vlt/VltContext.java
+++ b/vault-vlt/src/main/java/org/apache/jackrabbit/vault/vlt/VltContext.java
@@ -87,6 +87,8 @@ public class VltContext {
 
     private PathFilter globalIgnored;
 
+    private boolean allowInsecureHttps = false;
+
     public VltContext(File cwd, File localFile,
             RepositoryProvider repProvider,
             CredentialsStore credsProvider)
@@ -244,7 +246,7 @@ public class VltContext {
                     filter.setImportMode(ImportMode.REPLACE);
                 }
 
-                Repository rep = repProvider.getRepository(mountpoint);
+                Repository rep = repProvider.getRepository(mountpoint, isAllowInsecureHttps());
                 Credentials creds = credsProvider.getCredentials(mountpoint);
                 fs = Mounter.mount(config, filter, rep, creds, mountpoint, fsRoot);
                 // hack to store credentials
@@ -352,7 +354,7 @@ public class VltContext {
             stdout.flush();
         }
     }
-    
+
     public void printMessage(String msg, VltFile file) {
         if (!quiet) {
             String path = getCwdRelativePath(file.getPath());
@@ -422,4 +424,11 @@ public class VltContext {
         this.quiet = quiet;
     }
 
+    public boolean isAllowInsecureHttps() {
+        return allowInsecureHttps;
+    }
+
+    public void setAllowInsecureHttps(boolean allowInsecureHttps) {
+        this.allowInsecureHttps = allowInsecureHttps;
+    }
 }


### PR DESCRIPTION
Provide insecure flag to enable access to https with expired certs.

Adding a new cli argument `--insecure`.

Enabling optional support for expired ssl certs when using https on development server with self generated certificates.

There is a corresponding PR in the required jackrabbit dependency apache/jackrabbit#88