### PR TITLE
JCRVLT-488 - PlatformNameFormat incorrectly sets repository names for nodes with double colons

### DIFF
--- a/vault-core/src/main/java/org/apache/jackrabbit/vault/util/PlatformNameFormat.java
+++ b/vault-core/src/main/java/org/apache/jackrabbit/vault/util/PlatformNameFormat.java
@@ -22,9 +22,9 @@ package org.apache.jackrabbit.vault.util;
  * 
  * <p>Illegal characters a
  * generally escaped using the url escaping format, i.e. replacing the char
- * by a '%' hex(char) sequence. special treatment is used for the ':' char
- * since it's used quite often as namespace prefix separator. the
- * PREFIX ':' NAME sequence is replaced by '_' PREFIX '_' NAME. item names
+ * by a '%' hex(char) sequence. Special treatment is used for the ':' char
+ * since it's used quite often as namespace prefix separator. The
+ * PREFIX ':' NAME sequence is replaced by '_' PREFIX '_' NAME. Item names
  * that would generate the same pattern are escaped with an extra leading '_'.
  * 
  * <p>Examples:
@@ -47,7 +47,7 @@ package org.apache.jackrabbit.vault.util;
  * +-------------------+----------------------+----+----+
  * </pre>
  * 
- * note for the 2nd set of examples the cases are very rare and justify the
+ * Note for the 2nd set of examples the cases are very rare and justify the
  * ugly '%' escaping.
  *
  */
@@ -80,6 +80,7 @@ public class PlatformNameFormat {
                          buf.append('_');
                      } else {
                          buf.append("%3a");
+                         escapeColon = true;
                      }
                      break;
                  case '_':

--- a/vault-core/src/main/java/org/apache/jackrabbit/vault/util/PlatformNameFormat.java
+++ b/vault-core/src/main/java/org/apache/jackrabbit/vault/util/PlatformNameFormat.java
@@ -64,7 +64,7 @@ public class PlatformNameFormat {
      * @return the (escaped) platform name.
      */
     public static String getPlatformName(String repositoryName) {
-        StringBuffer buf = new StringBuffer("_");
+        StringBuilder buf = new StringBuilder("_");
         boolean escapeColon = false;
         boolean useUnderscore = false;
         int numUnderscore = 0;
@@ -135,7 +135,7 @@ public class PlatformNameFormat {
      * @return the (unescaped) repository name.
      */
     public static String getRepositoryName(String platformName) {
-        StringBuffer buffer = new StringBuffer("_");
+        StringBuilder buffer = new StringBuilder("_");
         boolean firstUnderscore = false;
         for (int i=0; i<platformName.length(); i++) {
             char c = platformName.charAt(i);

--- a/vault-core/src/test/java/org/apache/jackrabbit/vault/util/PlatformNameTest.java
+++ b/vault-core/src/test/java/org/apache/jackrabbit/vault/util/PlatformNameTest.java
@@ -45,7 +45,8 @@ public class PlatformNameTest {
              {"cq_:test.jpg", "cq_%3atest.jpg"},
              {"_", "_"},
              {":", "%3a"},
-             {":test", "%3atest"}
+             {":test", "%3atest"},
+             {":oak:mount-libs-nodetype", "%3aoak%3amount-libs-nodetype"}
        });
     }
 

--- a/vault-core/src/test/java/org/apache/jackrabbit/vault/util/PlatformNameTest.java
+++ b/vault-core/src/test/java/org/apache/jackrabbit/vault/util/PlatformNameTest.java
@@ -17,48 +17,54 @@
 
 package org.apache.jackrabbit.vault.util;
 
-import java.util.HashMap;
-import java.util.Map;
+import static org.junit.Assert.assertEquals;
 
-import junit.framework.TestCase;
+import java.util.Arrays;
+import java.util.Collection;
 
-/**
- * {@code PlatformNameTest}...
- *
- */
-public class PlatformNameTest extends TestCase {
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
 
-    private Map<String, String> names = new HashMap<String, String>();
-
-
-    protected void setUp() throws Exception {
-        names.put("test.jpg", "test.jpg");
-        names.put("cq:content", "_cq_content");
-        names.put("cq:test_image.jpg", "_cq_test_image.jpg");
-        names.put("test_image.jpg", "test_image.jpg");
-        names.put("_testimage.jpg", "_testimage.jpg");
-        names.put("_test_image.jpg", "__test_image.jpg");
-        names.put("cq:test:image.jpg", "_cq_test%3aimage.jpg");
-        names.put("_cq_:test.jpg", "__cq_%3atest.jpg");
-        names.put("_cq:test.jpg", "_cq%3atest.jpg");
-        names.put("cq_:test.jpg", "cq_%3atest.jpg");
-        names.put("_", "_");
-        names.put(":", "%3a");
-        names.put(":test", "%3atest");
+@RunWith(Parameterized.class)
+public class PlatformNameTest {
+    
+    @Parameters(name = "platform: {0}, repo: {1}")
+    public static Collection<Object[]> data() {
+        return Arrays.asList(new Object[][] {     
+             { "test.jpg", "test.jpg" },
+             {"cq:content", "_cq_content"},
+             {"cq:test_image.jpg", "_cq_test_image.jpg"},
+             {"test_image.jpg", "test_image.jpg"},
+             {"_testimage.jpg", "_testimage.jpg"},
+             {"_test_image.jpg", "__test_image.jpg"},
+             {"cq:test:image.jpg", "_cq_test%3aimage.jpg"},
+             {"_cq_:test.jpg", "__cq_%3atest.jpg"},
+             {"_cq:test.jpg", "_cq%3atest.jpg"},
+             {"cq_:test.jpg", "cq_%3atest.jpg"},
+             {"_", "_"},
+             {":", "%3a"},
+             {":test", "%3atest"}
+       });
     }
 
-    public void testToPlatform() {
-        for (String repName: names.keySet()) {
-            String pfName = names.get(repName);
-            assertEquals("Repo("+repName+")->Platform", pfName, PlatformNameFormat.getPlatformName(repName));
-        }
+    private final String repoName;
+    private final String platformName;
+    
+    public PlatformNameTest(String repoName, String platformName) {
+        this.repoName = repoName;
+        this.platformName = platformName;
     }
 
-    public void testToRepo() {
-        for (String repName: names.keySet()) {
-            String pfName = names.get(repName);
-            assertEquals("Platform("+pfName+")->Repo", repName, PlatformNameFormat.getRepositoryName(pfName));
-        }
+    @Test
+    public void toPlatform() {
+        assertEquals(platformName, PlatformNameFormat.getPlatformName(repoName));
+    }
+
+    @Test
+    public void toRepo() {
+        assertEquals(repoName, PlatformNameFormat.getRepositoryName(platformName));
     }
 
 }


### PR DESCRIPTION
Minor cleanups + a failing test case.