### PR TITLE
Fix filter mode attribute definition in filter.xsd

### DIFF
--- a/vault-validation/src/main/resources/filter.xsd
+++ b/vault-validation/src/main/resources/filter.xsd
@@ -50,7 +50,7 @@
             </xs:choice>
             <xs:attribute type="xs:string" name="root" use="required"/>
             <xs:attribute ref="type"/>
-            <xs:attribute type="xs:string" name="mode"/>
+            <xs:attribute ref="mode"/>
           </xs:complexType>
         </xs:element>
       </xs:sequence>


### PR DESCRIPTION
I noticed that the filter `mode` attribute is simply defined as a string, rather than a reference to the `mode` attribute definition from line 33.
It may result in incorrect schema validations, because any string will be allowed, instead of: `replace`, `merge`, `update`.