### PR TITLE
JCRVLT-497 correctly switch context if authorizable node is first

### DIFF
--- a/vault-validation/src/main/java/org/apache/jackrabbit/vault/validation/spi/impl/nodetype/JcrNodeTypeMetaDataImpl.java
+++ b/vault-validation/src/main/java/org/apache/jackrabbit/vault/validation/spi/impl/nodetype/JcrNodeTypeMetaDataImpl.java
@@ -106,7 +106,7 @@ public class JcrNodeTypeMetaDataImpl implements JcrNodeTypeMetaData {
     private final @NotNull Map<Name, JcrNodeTypeMetaDataImpl> childNodesByName;
     private final @Nullable JcrNodeTypeMetaDataImpl parentNode;
     private final Collection<ValidationMessage> messages;
-    private final boolean isAuthenticationOrAuthorizationContext;
+    private boolean isAuthenticationOrAuthorizationContext;
     private final boolean isImplicit; // if this is true, the node type is set implicitly (not explicitly set in package, used as is in the
                                       // repository)
     private boolean isValidationDone;
@@ -151,6 +151,9 @@ public class JcrNodeTypeMetaDataImpl implements JcrNodeTypeMetaData {
         if (effectiveNodeType == null || !effectiveNodeType.includesNodeTypes(types.toArray(new Name[0]))) {
             this.primaryNodeType = types.get(0);
             this.effectiveNodeType = effectiveNodeTypeProvider.getEffectiveNodeType(types.toArray(new Name[0]));
+            if (!isAuthenticationOrAuthorizationContext) {
+                isAuthenticationOrAuthorizationContext = isAclOrAuthorizableNodeType(effectiveNodeType);
+            }
         }
     }
 

--- a/vault-validation/src/test/java/org/apache/jackrabbit/vault/validation/spi/impl/nodetype/NodeTypeValidatorTest.java
+++ b/vault-validation/src/test/java/org/apache/jackrabbit/vault/validation/spi/impl/nodetype/NodeTypeValidatorTest.java
@@ -34,6 +34,7 @@ import org.apache.jackrabbit.JcrConstants;
 import org.apache.jackrabbit.commons.cnd.ParseException;
 import org.apache.jackrabbit.spi.Name;
 import org.apache.jackrabbit.spi.commons.name.NameConstants;
+import org.apache.jackrabbit.spi.commons.name.NameFactoryImpl;
 import org.apache.jackrabbit.vault.fs.api.WorkspaceFilter;
 import org.apache.jackrabbit.vault.fs.config.ConfigurationException;
 import org.apache.jackrabbit.vault.fs.config.DefaultWorkspaceFilter;
@@ -56,6 +57,9 @@ public class NodeTypeValidatorTest {
     private NodeTypeValidator validator;
     private DefaultWorkspaceFilter filter;
 
+    static final Name REP_AUTHORIZABLE_ID = NameFactoryImpl.getInstance().create(Name.NS_REP_URI, "authorizableId");
+    static final Name REP_PRINCIPAL_NAME = NameFactoryImpl.getInstance().create(Name.NS_REP_URI, "principalName");
+    
     @Before
     public void setUp() throws IOException, ConfigurationException, RepositoryException, ParseException {
         filter = new DefaultWorkspaceFilter();
@@ -310,4 +314,25 @@ public class NodeTypeValidatorTest {
         Assert.assertThat(validator.done(), AnyValidationMessageMatcher.noValidationInCollection());
     }
 
+    @Test
+    public void testAuthorizableNodes() {
+        // the folder is detected first
+        NodeContext nodeContext = new NodeContextImpl("/home/users/system/systemuser", Paths.get("node4"), Paths.get(""));
+        Assert.assertThat(validator.validateJcrPath(nodeContext, true, false),
+                AnyValidationMessageMatcher.noValidationInCollection());
+        Map<String, DocViewProperty> props = new HashMap<>();
+        props.put(NameConstants.JCR_PRIMARYTYPE.toString(), new DocViewProperty(NameConstants.JCR_PRIMARYTYPE.toString(),
+                new String[] { "rep:SystemUser" }, false, PropertyType.STRING));
+        props.put(NameConstants.JCR_UUID.toString(), new DocViewProperty(NameConstants.JCR_UUID.toString(),
+                new String[] { "41699399-95fd-444d-ab8c-b9f8e614607e" }, false, PropertyType.STRING));
+        props.put(REP_AUTHORIZABLE_ID.toString(), new DocViewProperty(REP_AUTHORIZABLE_ID.toString(),
+                new String[] { "systemuser" }, false, PropertyType.STRING));
+        props.put(REP_PRINCIPAL_NAME.toString(), new DocViewProperty(REP_PRINCIPAL_NAME.toString(),
+                new String[] { "systemuser" }, false, PropertyType.STRING));
+        // then the actual doctype with the user
+        DocViewNode node = new DocViewNode("jcr:root", "jcr:root", null, props, new String[] { }, "rep:SystemUser");
+        Assert.assertThat(validator.validate(node, nodeContext, true),
+                AnyValidationMessageMatcher.noValidationInCollection());
+        Assert.assertThat(validator.done(), AnyValidationMessageMatcher.noValidationInCollection());
+    }
 }


### PR DESCRIPTION
detected as simple nt:folder