### PR TITLE
JCRVLT-509 make importer strict by default

### DIFF
--- a/vault-core/src/main/java/org/apache/jackrabbit/vault/fs/io/ImportOptions.java
+++ b/vault-core/src/main/java/org/apache/jackrabbit/vault/fs/io/ImportOptions.java
@@ -27,13 +27,14 @@ import org.apache.jackrabbit.vault.fs.api.PathMapping;
 import org.apache.jackrabbit.vault.fs.api.ProgressTrackerListener;
 import org.apache.jackrabbit.vault.fs.api.WorkspaceFilter;
 import org.apache.jackrabbit.vault.packaging.DependencyHandling;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Option that control the package import.
  */
 public class ImportOptions {
 
-    private boolean strict;
+    private Boolean strict;
 
     private ProgressTrackerListener listener;
 
@@ -123,12 +124,26 @@ public class ImportOptions {
         return ret;
     }
 
+    public boolean isStrict(boolean isStrictByDefault) {
+        if (strict == null) {
+            return isStrictByDefault;
+        } else {
+            return strict;
+        }
+    }
+
     /**
      * Returns the 'strict' flag.
-     * @return the 'strict' flag.
+     * @return the 'strict' flag or {@code null} in case this is not set
+     * @deprecated Use {@link #isStrict(boolean)} instead.
      */
+    @Deprecated
     public boolean isStrict() {
-        return strict;
+        if (strict == null) {
+            return false;
+        } else {
+            return strict;
+        }
     }
 
     /**

--- a/vault-core/src/main/java/org/apache/jackrabbit/vault/fs/io/Importer.java
+++ b/vault-core/src/main/java/org/apache/jackrabbit/vault/fs/io/Importer.java
@@ -261,13 +261,20 @@ public class Importer {
      * list of intermediate infos that were removed since the last auto save
      */
     private Map<String, TxInfo> removedIntermediates = new LinkedHashMap<String, TxInfo>();
+    
+    private final boolean isStrictByDefault;
 
     public Importer() {
-         opts = new ImportOptions();
+         this(new ImportOptions(), false);
     }
 
     public Importer(ImportOptions opts) {
-         this.opts = opts;
+        this(opts, false);
+    }
+
+    public Importer(ImportOptions opts, boolean isStrictByDefault) {
+        this.opts = opts;
+        this.isStrictByDefault = isStrictByDefault;
     }
 
     public ImportOptions getOptions() {
@@ -276,6 +283,10 @@ public class Importer {
 
     public List<String> getSubPackages() {
         return subPackages;
+    }
+
+    public boolean isStrictByDefault() {
+        return isStrictByDefault;
     }
 
     /**
@@ -528,7 +539,7 @@ public class Importer {
                 log.debug("Installing node types...");
                 installer.install(tracker, nodeTypes);
             } catch (RepositoryException e) {
-                if (opts.isStrict()) {
+                if (opts.isStrict(isStrictByDefault)) {
                     throw e;
                 }
                 track(e, "Packaged node types");
@@ -546,7 +557,7 @@ public class Importer {
                 log.debug("Registering privileges...");
                 installer.install(tracker, privileges);
             } catch (RepositoryException e) {
-                if (opts.isStrict()) {
+                if (opts.isStrict(isStrictByDefault)) {
                     throw e;
                 }
                 track(e, "Packaged privileges");

--- a/vault-core/src/main/java/org/apache/jackrabbit/vault/fs/io/package-info.java
+++ b/vault-core/src/main/java/org/apache/jackrabbit/vault/fs/io/package-info.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-@Version("2.9.2")
+@Version("2.10.0")
 package org.apache.jackrabbit.vault.fs.io;
 
 import org.osgi.annotation.versioning.Version;

--- a/vault-core/src/main/java/org/apache/jackrabbit/vault/packaging/impl/JcrPackageImpl.java
+++ b/vault-core/src/main/java/org/apache/jackrabbit/vault/packaging/impl/JcrPackageImpl.java
@@ -386,7 +386,7 @@ public class JcrPackageImpl implements JcrPackage {
             // MAX_VALUE disables saving completely, therefore we have to use a lower value!
             opts.setAutoSaveThreshold(Integer.MAX_VALUE - 1);
         }
-        InstallContextImpl ctx = pack.prepareExtract(node.getSession(), opts, mgr.getSecurityConfig());
+        InstallContextImpl ctx = pack.prepareExtract(node.getSession(), opts, mgr.getSecurityConfig(), mgr.isStrictByDefault());
         JcrPackage snap = null;
         if (!opts.isDryRun() && createSnapshot) {
             ExportOptions eOpts = new ExportOptions();
@@ -483,7 +483,7 @@ public class JcrPackageImpl implements JcrPackage {
             try {
                 DependencyUtil.sortPackages(subPacks);
             } catch (CyclicDependencyException e) {
-                if (opts.isStrict()) {
+                if (opts.isStrict(mgr.isStrictByDefault())) {
                     throw e;
                 }
             }
@@ -986,7 +986,7 @@ public class JcrPackageImpl implements JcrPackage {
                 : ((JcrPackageDefinitionImpl) snap.getDefinition()).getSubPackages();
 
         if (snap == null) {
-            if (opts.isStrict()) {
+            if (opts.isStrict(mgr.isStrictByDefault())) {
                 throw new PackageException("Unable to uninstall package. No snapshot present.");
             }
             log.warn("Unable to revert package content {}. Snapshot missing.", getDefinition().getId());

--- a/vault-core/src/main/java/org/apache/jackrabbit/vault/packaging/impl/JcrPackageManagerImpl.java
+++ b/vault-core/src/main/java/org/apache/jackrabbit/vault/packaging/impl/JcrPackageManagerImpl.java
@@ -89,13 +89,15 @@ public class JcrPackageManagerImpl extends PackageManagerImpl implements JcrPack
      *
      * @param session repository session
      * @param roots the root paths to store the packages.
+     * @deprecated Use {@link #JcrPackageManagerImpl(Session, String[], String[], String[], boolean)} instead.
      */
+    @Deprecated
     public JcrPackageManagerImpl(@NotNull Session session, @Nullable String[] roots) {
         this(new JcrPackageRegistry(session, roots));
     }
 
-    public JcrPackageManagerImpl(@NotNull Session session, @Nullable String[] roots, @Nullable String[] authIdsForHookExecution, @Nullable String[] authIdsForRootInstallation) {
-        this(new JcrPackageRegistry(session, new AbstractPackageRegistry.SecurityConfig(authIdsForHookExecution, authIdsForRootInstallation), roots));
+    public JcrPackageManagerImpl(@NotNull Session session, @Nullable String[] roots, @Nullable String[] authIdsForHookExecution, @Nullable String[] authIdsForRootInstallation, boolean isStrict) {
+        this(new JcrPackageRegistry(session, new AbstractPackageRegistry.SecurityConfig(authIdsForHookExecution, authIdsForRootInstallation), isStrict, roots));
     }
 
     protected JcrPackageManagerImpl(JcrPackageRegistry registry) {

--- a/vault-core/src/main/java/org/apache/jackrabbit/vault/packaging/impl/PackagingImpl.java
+++ b/vault-core/src/main/java/org/apache/jackrabbit/vault/packaging/impl/PackagingImpl.java
@@ -99,6 +99,9 @@ public class PackagingImpl implements Packaging {
         
         @AttributeDefinition(description = "The authorizable ids which are allowed to install packages with the 'requireRoot' flag (in addition to 'admin', 'administrators' and 'system'")
         String[] authIdsForRootInstallation();
+        
+        @AttributeDefinition(description = "The default value for strict imports (i.e. whether it just logs certain errors or always throws exceptions")
+        boolean isStrict() default true;
     }
 
     @Activate
@@ -119,7 +122,7 @@ public class PackagingImpl implements Packaging {
      * {@inheritDoc}
      */
     public JcrPackageManager getPackageManager(Session session) {
-        JcrPackageManagerImpl mgr = new JcrPackageManagerImpl(session, config.packageRoots(), config.authIdsForHookExecution(), config.authIdsForRootInstallation());
+        JcrPackageManagerImpl mgr = new JcrPackageManagerImpl(session, config.packageRoots(), config.authIdsForHookExecution(), config.authIdsForRootInstallation(), config.isStrict());
         mgr.setDispatcher(eventDispatcher);
         setBaseRegistry(mgr.getInternalRegistry(), registries);
         return mgr;
@@ -167,7 +170,7 @@ public class PackagingImpl implements Packaging {
     }
 
     private JcrPackageRegistry getJcrPackageRegistry(Session session, boolean useBaseRegistry) {
-        JcrPackageRegistry registry = new JcrPackageRegistry(session, new AbstractPackageRegistry.SecurityConfig(config.authIdsForHookExecution(), config.authIdsForRootInstallation()), config.packageRoots());
+        JcrPackageRegistry registry = new JcrPackageRegistry(session, new AbstractPackageRegistry.SecurityConfig(config.authIdsForHookExecution(), config.authIdsForRootInstallation()), config.isStrict(), config.packageRoots());
         registry.setDispatcher(eventDispatcher);
         if (useBaseRegistry) {
             setBaseRegistry(registry, registries);

--- a/vault-core/src/main/java/org/apache/jackrabbit/vault/packaging/impl/ZipVaultPackage.java
+++ b/vault-core/src/main/java/org/apache/jackrabbit/vault/packaging/impl/ZipVaultPackage.java
@@ -155,15 +155,15 @@ public class ZipVaultPackage extends PackagePropertiesImpl implements VaultPacka
      * @throws PackageException if an error during packaging occurs
      * @throws RepositoryException if a repository error during installation occurs.
      */
-    public void extract(Session session, ImportOptions opts, @NotNull AbstractPackageRegistry.SecurityConfig securityConfig) throws PackageException, RepositoryException {
-        extract(prepareExtract(session, opts, securityConfig), null);
+    public void extract(Session session, ImportOptions opts, @NotNull AbstractPackageRegistry.SecurityConfig securityConfig, boolean isStrict) throws PackageException, RepositoryException {
+        extract(prepareExtract(session, opts, securityConfig, isStrict), null);
     }
     
     /**
      * {@inheritDoc}
      */
     public void extract(Session session, ImportOptions opts) throws RepositoryException, PackageException {
-        extract(session, opts, new AbstractPackageRegistry.SecurityConfig(null, null));
+        extract(session, opts, new AbstractPackageRegistry.SecurityConfig(null, null), false);
     }
 
     /**
@@ -184,7 +184,7 @@ public class ZipVaultPackage extends PackagePropertiesImpl implements VaultPacka
      * @throws IllegalStateException if the package is not valid.
      * @return installation context
      */
-    protected InstallContextImpl prepareExtract(Session session, ImportOptions opts,@NotNull AbstractPackageRegistry.SecurityConfig securityConfig) throws PackageException, RepositoryException {
+    protected InstallContextImpl prepareExtract(Session session, ImportOptions opts, @NotNull AbstractPackageRegistry.SecurityConfig securityConfig, boolean isStrictByDefault) throws PackageException, RepositoryException {
         if (!isValid()) {
             throw new IllegalStateException("Package not valid.");
         }
@@ -198,7 +198,7 @@ public class ZipVaultPackage extends PackagePropertiesImpl implements VaultPacka
 
         checkAllowanceToInstallPackage(session, hooks, securityConfig);
 
-        Importer importer = new Importer(opts);
+        Importer importer = new Importer(opts, isStrictByDefault);
         AccessControlHandling ac = getACHandling();
         if (opts.getAccessControlHandling() == null) {
             opts.setAccessControlHandling(ac);
@@ -265,7 +265,7 @@ public class ZipVaultPackage extends PackagePropertiesImpl implements VaultPacka
                 hooks.execute(ctx);
                 throw new PackageException("Error while executing an install hook during installed phase.");
             }
-            if (importer.hasErrors() && ctx.getOptions().isStrict()) {
+            if (importer.hasErrors() && ctx.getOptions().isStrict(importer.isStrictByDefault())) {
                 ctx.setPhase(InstallContext.Phase.INSTALL_FAILED);
                 hooks.execute(ctx);
                 throw new PackageException("Errors during import.");

--- a/vault-core/src/main/java/org/apache/jackrabbit/vault/packaging/registry/impl/AbstractPackageRegistry.java
+++ b/vault-core/src/main/java/org/apache/jackrabbit/vault/packaging/registry/impl/AbstractPackageRegistry.java
@@ -78,13 +78,22 @@ public abstract class AbstractPackageRegistry implements PackageRegistry, Intern
 
     protected @NotNull SecurityConfig securityConfig;
 
-    public AbstractPackageRegistry(SecurityConfig securityConfig) {
+    /** whether package imports should be strict by default (can be overwritten by {@link ImportOptions#setStrict(boolean)})
+     * 
+     */
+    private final boolean isStrictByDefault;
+
+    public AbstractPackageRegistry(SecurityConfig securityConfig, boolean isStrictByDefault) {
         if (securityConfig != null) {
             this.securityConfig = securityConfig;
         } else {
             this.securityConfig = new SecurityConfig(null, null);
         }
-        
+        this.isStrictByDefault = isStrictByDefault;
+    }
+
+    public boolean isStrictByDefault() {
+        return isStrictByDefault;
     }
 
     /**

--- a/vault-core/src/main/java/org/apache/jackrabbit/vault/packaging/registry/impl/FSPackageRegistry.java
+++ b/vault-core/src/main/java/org/apache/jackrabbit/vault/packaging/registry/impl/FSPackageRegistry.java
@@ -125,7 +125,9 @@ public class FSPackageRegistry extends AbstractPackageRegistry {
      *
      * @param homeDir the directory in which packages and their metadata is stored
      * @throws IOException If an I/O error occurs.
+     * @deprecated Use {@link #FSPackageRegistry(File, InstallationScope, SecurityConfig, boolean)} instead
      */
+    @Deprecated
     public FSPackageRegistry(@NotNull File homeDir) throws IOException {
         this(homeDir, InstallationScope.UNSCOPED);
     }
@@ -136,24 +138,40 @@ public class FSPackageRegistry extends AbstractPackageRegistry {
      * @param homeDir the directory in which packages and their metadata is stored
      * @param scope to set a corresponding workspacefilter
      * @throws IOException If an I/O error occurs.
+     * @deprecated Use {@link #FSPackageRegistry(File, InstallationScope, SecurityConfig, boolean)} instead
      */
+    @Deprecated
     public FSPackageRegistry(@NotNull File homeDir, InstallationScope scope) throws IOException {
        this(homeDir, scope, null);
     }
 
+    /**
+     * 
+     * @param homeDir
+     * @param scope
+     * @param securityConfig
+     * @throws IOException
+     * @deprecated Use {@link #FSPackageRegistry(File, InstallationScope, SecurityConfig, boolean)} instead
+     */
+    @Deprecated
     public FSPackageRegistry(@NotNull File homeDir, InstallationScope scope, @Nullable AbstractPackageRegistry.SecurityConfig securityConfig) throws IOException {
-        super(securityConfig);
+        this(homeDir, scope, securityConfig, false);
+    }
+
+    public FSPackageRegistry(@NotNull File homeDir, InstallationScope scope, @Nullable AbstractPackageRegistry.SecurityConfig securityConfig, boolean isStrict) throws IOException {
+        super(securityConfig, isStrict);
         this.homeDir = homeDir;
         log.info("Jackrabbit Filevault FS Package Registry initialized with home location {}", this.homeDir.getPath());
         this.scope = scope;
         loadPackageCache();
     }
+
     /**
      * Default constructor for OSGi initialization (homeDir defined via activator)
      * @throws IOException 
      */
     public FSPackageRegistry() throws IOException {
-        super(null); // set security config delayed (i.e. only after activate())
+        super(null, false); // set security config delayed (i.e. only after activate())
     }
 
     @Activate
@@ -701,7 +719,7 @@ public class FSPackageRegistry extends AbstractPackageRegistry {
                     // no need to set filter in other cases
                 
             }
-            ((ZipVaultPackage)vltPkg).extract(session, opts, getSecurityConfig());
+            ((ZipVaultPackage)vltPkg).extract(session, opts, getSecurityConfig(), isStrictByDefault());
             dispatch(PackageEvent.Type.EXTRACT, pkg.getId(), null);
             updateInstallState(vltPkg.getId(), FSPackageStatus.EXTRACTED);
 

--- a/vault-core/src/main/java/org/apache/jackrabbit/vault/packaging/registry/impl/JcrPackageRegistry.java
+++ b/vault-core/src/main/java/org/apache/jackrabbit/vault/packaging/registry/impl/JcrPackageRegistry.java
@@ -111,18 +111,17 @@ public class JcrPackageRegistry extends AbstractPackageRegistry {
      */
     private PackageRegistry baseRegistry = null;
 
-
     /**
      * Creates a new JcrPackageRegistry based on the given session.
      * @param session the JCR session that is used to access the repository.
      * @param roots the root paths to store the packages.
      */
     public JcrPackageRegistry(@NotNull Session session, @Nullable String ... roots) {
-        this(session, null, roots);
+        this(session, null, false, roots);
     }
 
-    public JcrPackageRegistry(@NotNull Session session, @Nullable AbstractPackageRegistry.SecurityConfig securityConfig, @Nullable String... roots) {
-        super(securityConfig);
+    public JcrPackageRegistry(@NotNull Session session, @Nullable AbstractPackageRegistry.SecurityConfig securityConfig,  boolean isStrict, @Nullable String... roots) {
+        super(securityConfig, isStrict);
         this.session = session;
         if (roots == null || roots.length == 0) {
             packRootPaths = new String[]{DEFAULT_PACKAGE_ROOT_PATH};

--- a/vault-core/src/test/java/org/apache/jackrabbit/vault/packaging/integration/PackageInstallIT.java
+++ b/vault-core/src/test/java/org/apache/jackrabbit/vault/packaging/integration/PackageInstallIT.java
@@ -254,7 +254,7 @@ public class PackageInstallIT extends IntegrationTestBase {
         
         Session userSession = repository.login(new SimpleCredentials(userId, userPwd.toCharArray()));
         try {
-            packMgr = new JcrPackageManagerImpl(userSession, new String[0], null, null);
+            packMgr = new JcrPackageManagerImpl(userSession, new String[0]);
     
             PackageEventDispatcherImpl dispatcher = new PackageEventDispatcherImpl();
             dispatcher.bindPackageEventListener(new ActivityLog(), Collections.singletonMap("component.id", (Object) "1234"));
@@ -297,7 +297,7 @@ public class PackageInstallIT extends IntegrationTestBase {
         
         Session userSession = repository.login(new SimpleCredentials(userId, userPwd.toCharArray()));
         try {
-            packMgr = new JcrPackageManagerImpl(userSession, new String[0], new String[] {"user1"}, null);
+            packMgr = new JcrPackageManagerImpl(userSession, new String[0], new String[] {"user1"}, null, false);
     
             PackageEventDispatcherImpl dispatcher = new PackageEventDispatcherImpl();
             dispatcher.bindPackageEventListener(new ActivityLog(), Collections.singletonMap("component.id", (Object) "1234"));
@@ -773,7 +773,7 @@ public class PackageInstallIT extends IntegrationTestBase {
         admin.save();
 
         Session session = repository.login(new SimpleCredentials(userId, userPwd.toCharArray()));
-        JcrPackageManagerImpl userPackMgr = new JcrPackageManagerImpl(session, new String[0], null, null);
+        JcrPackageManagerImpl userPackMgr = new JcrPackageManagerImpl(session, new String[0]);
         pack = userPackMgr.open(id);
         ImportOptions opts = getDefaultOptions();
         pack.install(opts);
@@ -816,7 +816,7 @@ public class PackageInstallIT extends IntegrationTestBase {
         admin.save();
 
         Session session = repository.login(new SimpleCredentials(userId, userPwd.toCharArray()));
-        JcrPackageManagerImpl userPackMgr = new JcrPackageManagerImpl(session, new String[0], null, null);
+        JcrPackageManagerImpl userPackMgr = new JcrPackageManagerImpl(session, new String[0]);
         pack = userPackMgr.open(id);
         ImportOptions opts = getDefaultOptions();
         pack.extract(opts);


### PR DESCRIPTION
the strict default value can be modified via OSGi configuration and can
still be overwritten with ImportOptions.setStrict(boolean)