### PR TITLE
JCRVLT-517 FSPackageRegistry.contains does not initialize packages

### DIFF
--- a/vault-core/src/main/java/org/apache/jackrabbit/vault/packaging/registry/impl/FSPackageRegistry.java
+++ b/vault-core/src/main/java/org/apache/jackrabbit/vault/packaging/registry/impl/FSPackageRegistry.java
@@ -246,6 +246,9 @@ public class FSPackageRegistry extends AbstractPackageRegistry {
 
     @Override
     public boolean contains(@NotNull PackageId id) throws IOException {
+        if (!packagesInitializied) {
+            loadPackageCache();
+        }
         return stateCache.containsKey(id);
     }
 


### PR DESCRIPTION
This solves https://issues.apache.org/jira/browse/JCRVLT-517 :

The implementation of FSPackageRegistry.contains did just `return stateCache.containsKey(id);` without initializing the stateCache, as e.g. the method packages() (line 640) does. I strongly suggest that it should initialize the stateCache (that is, call loadPackageCache() ) if it wasn't initialized before returning.

I stumbled over this because I'm using the Sling Feature Launcher and apply to org.apache.sling.jcr.packageinit triggered by org.apache.sling.extension.content to deploy content packages from the feature launcher, and this always fails since it says the packages aren't found. The reason for this is that org.apache.jackrabbit.vault.packaging.registry.impl.ExecutionPlanBuilderImpl.validate gets called, which uses FSPackageRegistry.contains, and this fails since the FSPackageRegistry isn't initialized yet.


Please note that getInstallState and setInstallState might have a similar problem, but I don't want to change anything if I don't know a good reason to do that and I couldn't tell what consequences that might have.