### PR TITLE
JCRVLT-525 fix corruption of the XML files of the FSPackageRegistry

### DIFF
--- a/vault-core/src/main/java/org/apache/jackrabbit/vault/packaging/registry/impl/FSInstallState.java
+++ b/vault-core/src/main/java/org/apache/jackrabbit/vault/packaging/registry/impl/FSInstallState.java
@@ -302,7 +302,7 @@ public class FSInstallState {
      */
     public void save(Path file) throws IOException {
         Files.createDirectories(file.getParent());
-        try (OutputStream out = Files.newOutputStream(file, StandardOpenOption.CREATE)) {
+        try (OutputStream out = Files.newOutputStream(file)) {
             save(out);
         }
     }


### PR DESCRIPTION
When the FSPackageRegistry is updated such that the XML files that save the state for each package will become corrupt if they are shorter than before. They are not truncated when they are rewritten, and if they become shorter, there are remnants of the old XML after the end of the newly written XML, so that there is a SAXParseException when they are read again). This is a simple fix that solves that problem and makes it usable again.