### PR TITLE
JCRVLT-542 do not modify primary types for import mode != REPLACE

### DIFF
--- a/vault-core/src/main/java/org/apache/jackrabbit/vault/fs/impl/io/FolderArtifactHandler.java
+++ b/vault-core/src/main/java/org/apache/jackrabbit/vault/fs/impl/io/FolderArtifactHandler.java
@@ -105,7 +105,7 @@ public class FolderArtifactHandler extends AbstractArtifactHandler {
             }
 
             Node node = parent.getNode(dir.getRelativePath());
-            if (wspFilter.contains(node.getPath()) && !nodeType.equals(node.getPrimaryNodeType().getName())) {
+            if (wspFilter.contains(node.getPath()) && wspFilter.getImportMode(node.getPath())==ImportMode.REPLACE && !nodeType.equals(node.getPrimaryNodeType().getName())) {
                 modifyPrimaryType(node, info);
             }
             NodeIterator iter = node.getNodes();
@@ -159,7 +159,7 @@ public class FolderArtifactHandler extends AbstractArtifactHandler {
             }
         }
         node.setPrimaryType(nodeType);
-       
+        info.onModified(node.getPath());
     }
 
     private void ensureCheckedOut(Node node, ImportInfoImpl info) throws RepositoryException {

--- a/vault-core/src/test/java/org/apache/jackrabbit/vault/packaging/integration/FolderArtifactHandlerIT.java
+++ b/vault-core/src/test/java/org/apache/jackrabbit/vault/packaging/integration/FolderArtifactHandlerIT.java
@@ -80,7 +80,7 @@ public class FolderArtifactHandlerIT extends IntegrationTestBase {
     public void testCreatingIntermediateNodesWithDefaultType() throws RepositoryException, IOException, PackageException {
         // create node "/var/foo" with node type "nt:unstructured"
         Node rootNode = admin.getRootNode();
-        Node testNode = rootNode.addNode("var", "nt:unstructured");
+        rootNode.addNode("var", "nt:unstructured");
         admin.save();
         try (VaultPackage vltPackage = extractVaultPackageStrict("/test-packages/folder-without-docview-element.zip")) {
             assertNodeHasPrimaryType("/var/foo", "nt:unstructured");
@@ -91,12 +91,28 @@ public class FolderArtifactHandlerIT extends IntegrationTestBase {
     public void testCreatingIntermediateNodesWithFallbackType() throws RepositoryException, IOException, PackageException {
         // create node "/var/foo" with node type "nt:unstructured"
         Node rootNode = admin.getRootNode();
-        Node testNode = rootNode.addNode("var", "nt:folder");
+        rootNode.addNode("var", "nt:folder");
         admin.save();
         assertNodeHasPrimaryType("/var", "nt:folder");
         try (VaultPackage vltPackage = extractVaultPackage("/test-packages/folder-without-docview-element.zip")) {
             assertNodeHasPrimaryType("/var", "nt:folder");
             assertNodeHasPrimaryType("/var/foo", "nt:folder");
+        }
+    }
+
+    // JCRVLT-542
+    @Test
+    public void testRootTypeOnMerge() throws RepositoryException, IOException, PackageException {
+        Node rootNode = admin.getRootNode();
+        Node homeNode = rootNode.getNode("home");
+        homeNode.addNode("groups", "rep:AuthorizableFolder");
+        admin.save();
+        assertNodeHasPrimaryType("/home", "rep:AuthorizableFolder");
+        assertNodeHasPrimaryType("/home/groups", "rep:AuthorizableFolder");
+        // /home/groups is being installed w/o any nodetype but filter is on mode=merge so no change expected
+        try (VaultPackage vltPackage = extractVaultPackage("/test-packages/test_nodetype_on_merge.zip")) {
+            assertNodeHasPrimaryType("/home", "rep:AuthorizableFolder");
+            assertNodeHasPrimaryType("/home/groups", "rep:AuthorizableFolder");
         }
     }
 }

--- a/vault-core/src/test/resources/test-packages/test_nodetype_on_merge.zip/META-INF/vault/config.xml
+++ b/vault-core/src/test/resources/test-packages/test_nodetype_on_merge.zip/META-INF/vault/config.xml
@@ -1,0 +1,77 @@
+<vaultfs version="1.1">
+    <!--
+        Defines the content aggregation. The order of the defined aggregates
+        is important for finding the correct aggregator.
+    -->
+    <aggregates>
+        <!--
+            Defines an aggregate that handles nt:file and nt:resource nodes.
+        -->
+        <aggregate type="file" title="File Aggregate"/>
+
+        <!--
+            Defines an aggregate that handles file/folder like nodes. It matches
+            all nt:hierarchyNode nodes that have or define a jcr:content
+            child node and excludes child nodes that are nt:hierarchyNodes.
+        -->
+        <aggregate type="filefolder" title="File/Folder Aggregate"/>
+
+        <!--
+            Defines an aggregate that handles nt:nodeType nodes and serializes
+            them into .cnd notation.
+        -->
+        <aggregate type="nodetype" title="Node Type Aggregate" />
+
+        <!--
+            Defines an aggregate that defines full coverage for certain node
+            types that cannot be covered by the default aggregator.
+        -->
+        <aggregate type="full" title="Full Coverage Aggregate">
+            <matches>
+                <include nodeType="rep:AccessControl" respectSupertype="true" />
+                <include nodeType="rep:Policy" respectSupertype="true" />
+                <include nodeType="cq:Widget" respectSupertype="true" />
+                <include nodeType="cq:EditConfig" respectSupertype="true" />
+                <include nodeType="cq:WorkflowModel" respectSupertype="true" />
+                <include nodeType="vlt:FullCoverage" respectSupertype="true" />
+                <include nodeType="mix:language" respectSupertype="true" />
+                <include nodeType="sling:OsgiConfig" respectSupertype="true" />
+            </matches>
+        </aggregate>
+
+        <!--
+            Defines an aggregate that handles nt:folder like nodes.
+        -->
+        <aggregate type="generic" title="Folder Aggregate">
+            <matches>
+                <include nodeType="nt:folder" respectSupertype="true" />
+            </matches>
+            <contains>
+                <exclude isNode="true" />
+            </contains>
+        </aggregate>
+
+        <!--
+            Defines the default aggregate
+        -->
+        <aggregate type="generic" title="Default Aggregator" isDefault="true">
+            <matches>
+                <!-- all -->
+            </matches>
+            <contains>
+                <exclude nodeType="nt:hierarchyNode" respectSupertype="true" />
+            </contains>
+        </aggregate>
+
+    </aggregates>
+
+    <!--
+      defines the input handlers
+    -->
+    <handlers>
+        <handler type="folder"/>
+        <handler type="file"/>
+        <handler type="nodetype"/>
+        <handler type="generic"/>
+    </handlers>
+</vaultfs>

--- a/vault-core/src/test/resources/test-packages/test_nodetype_on_merge.zip/META-INF/vault/definition/.content.xml
+++ b/vault-core/src/test/resources/test-packages/test_nodetype_on_merge.zip/META-INF/vault/definition/.content.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:vlt="http://www.day.com/jcr/vault/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0"
+    jcr:created="{Date}2011-06-07T14:32:17.432-07:00"
+    jcr:createdBy="admin"
+    jcr:description=""
+    jcr:lastModified="{Date}2011-06-07T14:32:17.432-07:00"
+    jcr:lastModifiedBy="admin"
+    jcr:primaryType="vlt:PackageDefinition"
+    buildCount="1"
+    cqVersion="5.3"
+    group="my_packages"
+    lastUnwrapped="{Date}2011-06-07T14:32:17.432-07:00"
+    lastUnwrappedBy="admin"
+    lastWrapped="{Date}2011-06-07T14:32:17.432-07:00"
+    lastWrappedBy="admin"
+    name="tmp_foo"
+    version="">
+    <filter jcr:primaryType="nt:unstructured">
+        <f0
+            jcr:primaryType="nt:unstructured"
+            mode="replace"
+            root="/tmp/foo"
+            rules="[]"/>
+    </filter>
+</jcr:root>

--- a/vault-core/src/test/resources/test-packages/test_nodetype_on_merge.zip/META-INF/vault/filter.xml
+++ b/vault-core/src/test/resources/test-packages/test_nodetype_on_merge.zip/META-INF/vault/filter.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<workspaceFilter version="1.0">
+    <filter root="/home" mode="merge"/>
+</workspaceFilter>

--- a/vault-core/src/test/resources/test-packages/test_nodetype_on_merge.zip/META-INF/vault/nodetypes.cnd
+++ b/vault-core/src/test/resources/test-packages/test_nodetype_on_merge.zip/META-INF/vault/nodetypes.cnd
@@ -1,0 +1,12 @@
+<'sling'='http://sling.apache.org/jcr/sling/1.0'>
+<'nt'='http://www.jcp.org/jcr/nt/1.0'>
+
+[sling:Folder] > nt:folder
+  - * (undefined)
+  - * (undefined) multiple
+  + * (nt:base) = sling:Folder version
+
+[sling:OrderedFolder] > sling:Folder
+  orderable
+  + * (nt:base) = sling:OrderedFolder version
+

--- a/vault-core/src/test/resources/test-packages/test_nodetype_on_merge.zip/META-INF/vault/properties.xml
+++ b/vault-core/src/test/resources/test-packages/test_nodetype_on_merge.zip/META-INF/vault/properties.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<!DOCTYPE properties SYSTEM "http://java.sun.com/dtd/properties.dtd">
+<properties>
+<comment>Testpackage for folder nodeType on filters with mode merge</comment>
+<entry key="createdBy">admin</entry>
+<entry key="name">test_nodetype_on_merge</entry>
+<entry key="lastModified">2011-06-07T14:32:17.432-07:00</entry>
+<entry key="lastModifiedBy">admin</entry>
+<entry key="created">2011-06-07T14:32:17.502-07:00</entry>
+<entry key="buildCount">1</entry>
+<entry key="version"/>
+<entry key="dependencies"/>
+<entry key="packageFormatVersion">2</entry>
+<entry key="description"/>
+<entry key="group">my_packages</entry>
+<entry key="path">/etc/packages/my_packages/test_nodetype_on_merge</entry>
+</properties>

--- a/vault-core/src/test/resources/test-packages/test_nodetype_on_merge.zip/jcr_root/.content.xml
+++ b/vault-core/src/test/resources/test-packages/test_nodetype_on_merge.zip/jcr_root/.content.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:rep="internal"
+    jcr:mixinTypes="[rep:AccessControllable]"
+    jcr:primaryType="rep:root"
+    sling:resourceType="sling:redirect"
+    sling:target="/welcome.html">
+    <home/>
+    <rep:policy/>
+    <jcr:system/>
+    <etc/>
+    <apps/>
+    <libs/>
+    <content/>
+    <var/>
+    <tmp/>
+</jcr:root>

--- a/vault-core/src/test/resources/test-packages/test_nodetype_on_merge.zip/jcr_root/home/groups/.content.xml
+++ b/vault-core/src/test/resources/test-packages/test_nodetype_on_merge.zip/jcr_root/home/groups/.content.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:rep="internal"
+    jcr:primaryType="rep:AuthorizableFolder"/>
+

--- a/vault-core/src/test/resources/test-packages/test_nodetype_on_merge.zip/jcr_root/home/groups/test/.content.xml
+++ b/vault-core/src/test/resources/test-packages/test_nodetype_on_merge.zip/jcr_root/home/groups/test/.content.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:rep="internal"
+    jcr:primaryType="rep:AuthorizableFolder"/>
+

--- a/vault-core/src/test/resources/test-packages/test_nodetype_on_merge.zip/jcr_root/home/groups/test/lXZzTxX_ZZkvjixvqJON/.content.xml
+++ b/vault-core/src/test/resources/test-packages/test_nodetype_on_merge.zip/jcr_root/home/groups/test/lXZzTxX_ZZkvjixvqJON/.content.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:rep="internal"
+    jcr:mixinTypes="[rep:AccessControllable]"
+    jcr:primaryType="rep:Group"
+    jcr:uuid="9628ffae-cf05-3138-8185-2cb572d50d45"
+    rep:authorizableId="testgroup"
+    rep:principalName="testgroup"/>


### PR DESCRIPTION
Correctly register modification of primary type for mode REPLACE

Co-authored-by: Dominik Suess <suess@adobe.com>