### PR TITLE
JCRVLT-543 ignore protected properties during import

### DIFF
--- a/vault-core/src/test/java/org/apache/jackrabbit/vault/packaging/integration/EmptyPackageIT.java
+++ b/vault-core/src/test/java/org/apache/jackrabbit/vault/packaging/integration/EmptyPackageIT.java
@@ -26,6 +26,7 @@ import javax.jcr.RepositoryException;
 import javax.jcr.nodetype.NodeType;
 
 import org.apache.jackrabbit.commons.JcrUtils;
+import org.apache.jackrabbit.vault.fs.io.ImportOptions;
 import org.apache.jackrabbit.vault.packaging.JcrPackage;
 import org.apache.jackrabbit.vault.packaging.PackageException;
 import org.junit.Test;
@@ -208,10 +209,12 @@ public class EmptyPackageIT extends IntegrationTestBase {
     public void installInstallNoFilter() throws RepositoryException, IOException, PackageException {
         JcrPackage pack = packMgr.upload(getStream("/test-packages/tmp_foo_bar_test_nofilter.zip"), false);
         assertNotNull(pack);
-        pack.install(getDefaultOptions());
+        ImportOptions opts = getDefaultOptions();
+        opts.setStrict(false);
+        pack.install(opts);
         assertNodeExists("/tmp/foo/bar/test.txt");
 
-        pack.uninstall(getDefaultOptions());
+        pack.uninstall(opts);
         assertNodeExists("/tmp/foo/bar/test.txt");
     }
 
@@ -223,10 +226,13 @@ public class EmptyPackageIT extends IntegrationTestBase {
     public void installInstallMinimal() throws RepositoryException, IOException, PackageException {
         JcrPackage pack = packMgr.upload(getStream("/test-packages/tmp_foo_bar_test_minimal.zip"), false);
         assertNotNull(pack);
-        pack.install(getDefaultOptions());
+        ImportOptions opts = getDefaultOptions();
+        opts.setStrict(false);
+        pack.install(opts);
+        
         assertNodeExists("/tmp/foo/bar/test.txt");
 
-        pack.uninstall(getDefaultOptions());
+        pack.uninstall(opts);
         assertNodeExists("/tmp/foo/bar/test.txt");
     }
 

--- a/vault-core/src/test/java/org/apache/jackrabbit/vault/packaging/integration/ImportIT.java
+++ b/vault-core/src/test/java/org/apache/jackrabbit/vault/packaging/integration/ImportIT.java
@@ -368,12 +368,14 @@ public class ImportIT extends IntegrationTestBase {
     }
 
     @Test
+    @SuppressWarnings("java:S5783")
     public void testImportWithPropertyConstraintViolation() throws IOException, RepositoryException, ConfigurationException {
         try (Archive archive = getFileArchive("/test-packages/property_constraint_violation.zip")) {
             Node rootNode = admin.getRootNode();
             ImportOptions opts = getDefaultOptions();
             Importer importer = new Importer(opts);
             archive.open(true);
+            // we don't care whether constraint is immediately enforced or only on save() as both is valid according to JCR spec
             RepositoryException e = Assert.assertThrows(RepositoryException.class, () -> { importer.run(archive, rootNode); admin.save(); });
             assertEquals(ConstraintViolationException.class, e.getCause().getClass());
         }

--- a/vault-core/src/test/java/org/apache/jackrabbit/vault/packaging/integration/IntegrationTestBase.java
+++ b/vault-core/src/test/java/org/apache/jackrabbit/vault/packaging/integration/IntegrationTestBase.java
@@ -459,6 +459,7 @@ public class IntegrationTestBase  {
     public ImportOptions getDefaultOptions() {
         ImportOptions opts = new ImportOptions();
         opts.setListener(getLoggingProgressTrackerListener());
+        opts.setStrict(true);
         return opts;
     }
 

--- a/vault-core/src/test/java/org/apache/jackrabbit/vault/packaging/integration/IntegrationTestBase.java
+++ b/vault-core/src/test/java/org/apache/jackrabbit/vault/packaging/integration/IntegrationTestBase.java
@@ -49,6 +49,7 @@ import javax.jcr.Node;
 import javax.jcr.NodeIterator;
 import javax.jcr.PathNotFoundException;
 import javax.jcr.Property;
+import javax.jcr.PropertyType;
 import javax.jcr.Repository;
 import javax.jcr.RepositoryException;
 import javax.jcr.Session;
@@ -505,6 +506,12 @@ public class IntegrationTestBase  {
         assertEquals(path + " should contain " + value, value, admin.getProperty(path).getString());
     }
 
+    public void assertProperty(String path,  boolean value) throws RepositoryException {
+        Property property = admin.getProperty(path);
+        assertEquals(path + " is no boolean property", PropertyType.BOOLEAN, property.getType());
+        assertEquals(path + " should contain boolean value " + value, property.getBoolean(), value);
+    }
+ 
     public void assertPropertyExists(String path) throws RepositoryException {
         assertTrue(path + " should exist", admin.propertyExists(path));
     }

--- a/vault-core/src/test/java/org/apache/jackrabbit/vault/packaging/integration/IntegrationTestBase.java
+++ b/vault-core/src/test/java/org/apache/jackrabbit/vault/packaging/integration/IntegrationTestBase.java
@@ -29,7 +29,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.StandardCopyOption;
 import java.util.ArrayList;

--- a/vault-core/src/test/java/org/apache/jackrabbit/vault/packaging/integration/PackageInstallIT.java
+++ b/vault-core/src/test/java/org/apache/jackrabbit/vault/packaging/integration/PackageInstallIT.java
@@ -500,11 +500,14 @@ public class PackageInstallIT extends IntegrationTestBase {
         assertNotNull(pack);
 
         // extract should not generate snapshots
-        pack.extract(getDefaultOptions());
+        ImportOptions opts = getDefaultOptions();
+        opts.setStrict(false);
+        
+        pack.extract(opts);
         assertNodeExists("/tmp/foo/bar/tobi");
         assertPackageNodeMissing(TMP_SNAPSHOT_PACKAGE_ID);
 
-        pack.uninstall(getDefaultOptions());
+        pack.uninstall(opts);
         assertNodeExists("/tmp/foo/bar/tobi");
     }
 
@@ -813,6 +816,7 @@ public class PackageInstallIT extends IntegrationTestBase {
         JcrPackageManagerImpl userPackMgr = new JcrPackageManagerImpl(session, new String[0]);
         pack = userPackMgr.open(id);
         ImportOptions opts = getDefaultOptions();
+        opts.setStrict(false);
         pack.extract(opts);
         pack.close();
         session.logout();

--- a/vault-core/src/test/resources/test-packages/property_constraint_violation.zip/META-INF/vault/filter.xml
+++ b/vault-core/src/test/resources/test-packages/property_constraint_violation.zip/META-INF/vault/filter.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<workspaceFilter version="1.0">
+    <filter root="/testroot"/>
+</workspaceFilter>

--- a/vault-core/src/test/resources/test-packages/property_constraint_violation.zip/META-INF/vault/nodetypes.cnd
+++ b/vault-core/src/test/resources/test-packages/property_constraint_violation.zip/META-INF/vault/nodetypes.cnd
@@ -1,0 +1,7 @@
+<'sling'='http://sling.apache.org/jcr/sling/1.0'>
+<'nt'='http://www.jcp.org/jcr/nt/1.0'>
+<'vlt'='http://www.day.com/jcr/vault/1.0'>
+<'my'='http://jackrabbit.apache.org/filevault/testing'>
+
+[my:Folder2] > nt:hierarchyNode
+  - * (name)

--- a/vault-core/src/test/resources/test-packages/property_constraint_violation.zip/META-INF/vault/properties.xml
+++ b/vault-core/src/test/resources/test-packages/property_constraint_violation.zip/META-INF/vault/properties.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<!DOCTYPE properties SYSTEM "http://java.sun.com/dtd/properties.dtd">
+<properties>
+<comment>FileVault Package Properties</comment>
+<entry key="createdBy">admin</entry>
+<entry key="name">import-modes-test</entry>
+<entry key="lastModified">2011-11-15T09:45:14.664+01:00</entry>
+<entry key="lastModifiedBy">admin</entry>
+<entry key="created">2011-11-15T09:45:14.685+01:00</entry>
+<entry key="buildCount">1</entry>
+<entry key="version"/>
+<entry key="dependencies"/>
+<entry key="packageFormatVersion">2</entry>
+<entry key="description"/>
+<entry key="lastWrapped">2011-11-15T09:45:14.664+01:00</entry>
+<entry key="group"/>
+<entry key="lastWrappedBy">admin</entry>
+</properties>

--- a/vault-core/src/test/resources/test-packages/property_constraint_violation.zip/jcr_root/.content.xml
+++ b/vault-core/src/test/resources/test-packages/property_constraint_violation.zip/jcr_root/.content.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:rep="internal"
+    jcr:mixinTypes="[rep:AccessControllable]"
+    jcr:primaryType="rep:root"
+    sling:resourceType="sling:redirect"
+    sling:target="/index.html">
+    <rep:policy/>
+    <jcr:system/>
+    <var/>
+    <libs/>
+    <etc/>
+    <apps/>
+    <content/>
+    <tmp/>
+    <home/>
+    <testroot/>
+</jcr:root>

--- a/vault-core/src/test/resources/test-packages/property_constraint_violation.zip/jcr_root/testroot/.content.xml
+++ b/vault-core/src/test/resources/test-packages/property_constraint_violation.zip/jcr_root/testroot/.content.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:rep="internal" xmlns:my="http://jackrabbit.apache.org/filevault/testing"
-    jcr:primaryType="my:Folder"
+    jcr:primaryType="my:Folder2"
     jcr:createdBy="myself"
-    someProtectedBooleanProperty="{Boolean}true"
-    someUnprotectedStringProperty="foo"
-    >
+    someNotAllowedStringProperty="{String}test">
 </jcr:root>

--- a/vault-core/src/test/resources/test-packages/protected_properties.zip/META-INF/vault/filter.xml
+++ b/vault-core/src/test/resources/test-packages/protected_properties.zip/META-INF/vault/filter.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<workspaceFilter version="1.0">
+    <filter root="/testroot"/>
+</workspaceFilter>

--- a/vault-core/src/test/resources/test-packages/protected_properties.zip/META-INF/vault/nodetypes.cnd
+++ b/vault-core/src/test/resources/test-packages/protected_properties.zip/META-INF/vault/nodetypes.cnd
@@ -1,0 +1,8 @@
+<'sling'='http://sling.apache.org/jcr/sling/1.0'>
+<'nt'='http://www.jcp.org/jcr/nt/1.0'>
+<'vlt'='http://www.day.com/jcr/vault/1.0'>
+<'my'='http://jackrabbit.apache.org/filevault/testing'>
+
+[my:Folder] > nt:hierarchyNode
+  - * (boolean) protected
+  - * (string)

--- a/vault-core/src/test/resources/test-packages/protected_properties.zip/META-INF/vault/properties.xml
+++ b/vault-core/src/test/resources/test-packages/protected_properties.zip/META-INF/vault/properties.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<!DOCTYPE properties SYSTEM "http://java.sun.com/dtd/properties.dtd">
+<properties>
+<comment>FileVault Package Properties</comment>
+<entry key="createdBy">admin</entry>
+<entry key="name">import-modes-test</entry>
+<entry key="lastModified">2011-11-15T09:45:14.664+01:00</entry>
+<entry key="lastModifiedBy">admin</entry>
+<entry key="created">2011-11-15T09:45:14.685+01:00</entry>
+<entry key="buildCount">1</entry>
+<entry key="version"/>
+<entry key="dependencies"/>
+<entry key="packageFormatVersion">2</entry>
+<entry key="description"/>
+<entry key="lastWrapped">2011-11-15T09:45:14.664+01:00</entry>
+<entry key="group"/>
+<entry key="lastWrappedBy">admin</entry>
+</properties>

--- a/vault-core/src/test/resources/test-packages/protected_properties.zip/jcr_root/.content.xml
+++ b/vault-core/src/test/resources/test-packages/protected_properties.zip/jcr_root/.content.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:rep="internal"
+    jcr:mixinTypes="[rep:AccessControllable]"
+    jcr:primaryType="rep:root"
+    sling:resourceType="sling:redirect"
+    sling:target="/index.html">
+    <rep:policy/>
+    <jcr:system/>
+    <var/>
+    <libs/>
+    <etc/>
+    <apps/>
+    <content/>
+    <tmp/>
+    <home/>
+    <testroot/>
+</jcr:root>

--- a/vault-core/src/test/resources/test-packages/protected_properties.zip/jcr_root/testroot/.content.xml
+++ b/vault-core/src/test/resources/test-packages/protected_properties.zip/jcr_root/testroot/.content.xml
@@ -3,6 +3,5 @@
     jcr:primaryType="my:Folder"
     jcr:createdBy="myself"
     someProtectedBooleanProperty="{Boolean}true"
-    someUnprotectedStringProperty="{String}foo"
-    >
+    someUnprotectedStringProperty="{String}foo">
 </jcr:root>

--- a/vault-core/src/test/resources/test-packages/protected_properties.zip/jcr_root/testroot/.content.xml
+++ b/vault-core/src/test/resources/test-packages/protected_properties.zip/jcr_root/testroot/.content.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:rep="internal"
+    jcr:primaryType="rep:AuthorizableFolder"
+    jcr:createdBy="myself"
+    
+    >
+</jcr:root>

--- a/vault-core/src/test/resources/test-packages/protected_properties.zip/jcr_root/testroot/.content.xml
+++ b/vault-core/src/test/resources/test-packages/protected_properties.zip/jcr_root/testroot/.content.xml
@@ -3,6 +3,6 @@
     jcr:primaryType="my:Folder"
     jcr:createdBy="myself"
     someProtectedBooleanProperty="{Boolean}true"
-    someUnprotectedStringProperty="foo"
+    someUnprotectedStringProperty="{String}foo"
     >
 </jcr:root>


### PR DESCRIPTION
dynamically determine if a property is protected
fail with an exception for all other constraint violations (in mode =
REPLACE)