### PR TITLE
JCRVLT-546 only increase minor version of o.a.j.v.fs as the removed

### DIFF
--- a/vault-core/pom.xml
+++ b/vault-core/pom.xml
@@ -71,6 +71,13 @@
             <plugin>
                 <groupId>biz.aQute.bnd</groupId>
                 <artifactId>bnd-baseline-maven-plugin</artifactId>
+                <configuration>
+                    <diffpackages>
+                        <!-- temporarily ignore baseline violation for o.a.j.v.fs due to https://issues.apache.org/jira/browse/JCRVLT-546?focusedCommentId=17379780&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-17379780 -->
+                        <diffpackage>!org.apache.jackrabbit.vault.fs</diffpackage>
+                        <diffpackage>*</diffpackage>
+                    </diffpackages>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/vault-core/src/main/java/org/apache/jackrabbit/vault/fs/package-info.java
+++ b/vault-core/src/main/java/org/apache/jackrabbit/vault/fs/package-info.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-@Version("3.0.0")
+@Version("2.5.0")
 package org.apache.jackrabbit.vault.fs;
 
 import org.osgi.annotation.versioning.Version;


### PR DESCRIPTION
classes could have never been referenced from other bundles in an OSGi
environment (due to private super class)