### PR TITLE
JCRVLT-561 prevent stack overflow in getArchive() for closed packages

### DIFF
--- a/vault-core/src/main/java/org/apache/jackrabbit/vault/packaging/VaultPackage.java
+++ b/vault-core/src/main/java/org/apache/jackrabbit/vault/packaging/VaultPackage.java
@@ -29,7 +29,7 @@ import org.osgi.annotation.versioning.ProviderType;
 
 /**
  * Defines a vault package. A vault package is a binary assembled representation
- * of a vault export.
+ * of a vault export. This is just a thin wrapper of an {@link Archive}.
  * <p>
  * Note that VaultPackage currently extends from PackageProperties to keep the interface backwards compatible.
  */

--- a/vault-core/src/main/java/org/apache/jackrabbit/vault/packaging/impl/PackagePropertiesImpl.java
+++ b/vault-core/src/main/java/org/apache/jackrabbit/vault/packaging/impl/PackagePropertiesImpl.java
@@ -75,6 +75,10 @@ public abstract class PackagePropertiesImpl implements PackageProperties {
         return id;
     }
 
+    protected @Nullable PackageId getCachedId() {
+        return id;
+    }
+
     /**
      * {@inheritDoc}
      */

--- a/vault-core/src/main/java/org/apache/jackrabbit/vault/packaging/impl/ZipVaultPackage.java
+++ b/vault-core/src/main/java/org/apache/jackrabbit/vault/packaging/impl/ZipVaultPackage.java
@@ -99,7 +99,8 @@ public class ZipVaultPackage extends PackagePropertiesImpl implements VaultPacka
     public Archive getArchive() {
         if (archive == null) {
             PackageId packageId = getCachedId();
-            throw new IllegalStateException("Package already closed" + packageId  != null ? " (" + packageId + ")": "");
+            String pidSuffix = (packageId != null) ? (" (" + packageId + ")") : "";
+            throw new IllegalStateException("Package already closed" + pidSuffix);
         }
         try {
             archive.open(false);

--- a/vault-core/src/main/java/org/apache/jackrabbit/vault/packaging/impl/ZipVaultPackage.java
+++ b/vault-core/src/main/java/org/apache/jackrabbit/vault/packaging/impl/ZipVaultPackage.java
@@ -39,6 +39,7 @@ import org.apache.jackrabbit.vault.packaging.InstallContext;
 import org.apache.jackrabbit.vault.packaging.InstallHookProcessor;
 import org.apache.jackrabbit.vault.packaging.InstallHookProcessorFactory;
 import org.apache.jackrabbit.vault.packaging.PackageException;
+import org.apache.jackrabbit.vault.packaging.PackageId;
 import org.apache.jackrabbit.vault.packaging.PackageProperties;
 import org.apache.jackrabbit.vault.packaging.VaultPackage;
 import org.apache.jackrabbit.vault.packaging.registry.impl.AbstractPackageRegistry;
@@ -70,7 +71,6 @@ public class ZipVaultPackage extends PackagePropertiesImpl implements VaultPacka
         this(OsgiAwarePropertiesUtil.getBooleanProperty(PROP_USE_NIO_ARCHIVE) ? new ZipNioArchive(file, isTmpFile) : new ZipArchive(file.toFile(), isTmpFile), strict);
     }
 
-    
     public ZipVaultPackage(Archive archive, boolean strict)
             throws IOException {
         this.archive = archive;
@@ -78,8 +78,7 @@ public class ZipVaultPackage extends PackagePropertiesImpl implements VaultPacka
             try {
                 archive.open(true);
             } catch (IOException e) {
-                log.error("Error while loading package {}.", archive);
-                throw e;
+                throw new IOException("Error while loading package " + archive, e);
             }
         }
     }
@@ -99,14 +98,13 @@ public class ZipVaultPackage extends PackagePropertiesImpl implements VaultPacka
      */
     public Archive getArchive() {
         if (archive == null) {
-            log.error("Package already closed: {}", getId());
-            throw new IllegalStateException("Package already closed: " + getId());
+            PackageId packageId = getCachedId();
+            throw new IllegalStateException("Package already closed" + packageId  != null ? " (" + packageId + ")": "");
         }
         try {
             archive.open(false);
         } catch (IOException e) {
-            log.error("Archive not valid.", e);
-            throw new IllegalStateException("Archive not valid.", e);
+            throw new IllegalStateException("Archive " + archive + " not valid.", e);
         }
         return archive;
     }

--- a/vault-core/src/test/java/org/apache/jackrabbit/vault/packaging/impl/ZipVaultPackageIT.java
+++ b/vault-core/src/test/java/org/apache/jackrabbit/vault/packaging/impl/ZipVaultPackageIT.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.jackrabbit.vault.packaging.impl;
+
+import java.io.IOException;
+
+import org.apache.jackrabbit.vault.packaging.integration.IntegrationTestBase;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class ZipVaultPackageIT extends IntegrationTestBase {
+
+    @Test
+    public void testGetClosedArchive() throws IOException {
+        ZipVaultPackage pkg = new ZipVaultPackage(getFile("/test-packages/tmp.zip"), false);
+        pkg.close();
+        Assert.assertThrows(IllegalStateException.class, () -> pkg.getArchive());
+    }
+}


### PR DESCRIPTION
never log and throw, but only one or the other!