### PR TITLE
JCRVLT-565 use isolated FSPackage registry directories per thread

### DIFF
--- a/vault-core/src/test/java/org/apache/jackrabbit/vault/packaging/integration/CrossRegistryDependenciesIT.java
+++ b/vault-core/src/test/java/org/apache/jackrabbit/vault/packaging/integration/CrossRegistryDependenciesIT.java
@@ -32,7 +32,7 @@ import org.junit.Test;
  */
 public class CrossRegistryDependenciesIT extends IntegrationTestBase {
 
-    private static final File DIR_REGISTRY_HOME = new File("target/registry");
+    private static final File DIR_REGISTRY_HOME = new File("target/fspackageregistry-" + System.getProperty("repoSuffix", "fork1"));
 
     private FSPackageRegistry fsregistry;
 

--- a/vault-core/src/test/java/org/apache/jackrabbit/vault/packaging/registry/impl/FSPackageRegistryIT.java
+++ b/vault-core/src/test/java/org/apache/jackrabbit/vault/packaging/registry/impl/FSPackageRegistryIT.java
@@ -73,7 +73,7 @@ import org.slf4j.LoggerFactory;
  */
 public class FSPackageRegistryIT extends IntegrationTestBase {
 
-    private static final File DIR_REGISTRY_HOME = new File("target/registry");
+    private static final File DIR_REGISTRY_HOME = new File("target/fspackageregistry-" + System.getProperty("repoSuffix", "fork1"));
 
     private static final Logger log = LoggerFactory.getLogger(FSPackageRegistryIT.class);
 


### PR DESCRIPTION
Make tests succeed which may be executed in parallel in multiple threads/processes