### PR TITLE
JCRVLT-593 mark embedded dependencies as scope "provided" as they should

### DIFF
--- a/vault-core/pom.xml
+++ b/vault-core/pom.xml
@@ -171,12 +171,15 @@
             <groupId>org.glassfish.jaxb</groupId>
             <artifactId>txw2</artifactId>
             <version>2.3.2</version>
+            <!-- embedded, therefore not transitively relevant -->
+            <scope>provided</scope>
         </dependency>
-        <!-- embed -->
         <dependency>
             <groupId>com.fasterxml.woodstox</groupId>
             <artifactId>woodstox-core</artifactId>
             <version>6.1.1</version>
+            <!-- embedded, therefore not transitively relevant -->
+            <scope>provided</scope>
         </dependency>
         
         <!-- SLF4j / Log4j -->
@@ -225,7 +228,9 @@
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-artifact</artifactId>
-            <version>3.8.1</version>
+            <version>3.8.4</version>
+            <!-- embedded, therefore not transitively relevant -->
+            <scope>provided</scope>
         </dependency>
         <!-- test deps -->
         <dependency>

--- a/vault-validation/pom.xml
+++ b/vault-validation/pom.xml
@@ -117,6 +117,18 @@
         </dependency>
 
         <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+        </dependency>
+
+        <!-- for parsing Maven versions -->
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-artifact</artifactId>
+            <version>3.8.4</version>
+        </dependency>
+
+        <dependency>
             <groupId>org.jetbrains</groupId>
             <artifactId>annotations</artifactId>
             <scope>provided</scope>


### PR DESCRIPTION
not be transitively inherited