### PR TITLE
JCRVLT-579 prevent embedding vulnerable libraries

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -21,7 +21,11 @@
 library "filevault@master"
 
 vaultPipeline('ubuntu', 11, '3', {
-   vaultStageBuild(['ubuntu', 'Windows'], [11, 17], ['3', '3.6.3'], 'apache_jackrabbit-filevault')
+   vaultStageBuild(['ubuntu', 'Windows'], [11, 17], ['3', '3.6.3'], 'apache_jackrabbit-filevault', 
+     [
+       mainBuildArguments: '-U clean site deploy -Pjacoco-report,dependency-check -Dlogback.configurationFile=vault-core/src/test/resources/logback-only-errors.xml'
+     ]
+   )
    vaultStageDeploy()
   }
 )

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -277,6 +277,21 @@ Bundle-Category: jackrabbit
                     <artifactId>jacoco-maven-plugin</artifactId>
                     <version>0.8.8</version>
                 </plugin>
+                <plugin>
+                    <groupId>org.owasp</groupId>
+                    <artifactId>dependency-check-maven</artifactId>
+                    <version>7.1.0</version>
+                    <executions>
+                        <execution>
+                            <goals>
+                                <goal>check</goal>
+                            </goals>
+                            <configuration>
+                                <failBuildOnAnyVulnerability>true</failBuildOnAnyVulnerability>
+                            </configuration>
+                        </execution>
+                    </executions>
+                </plugin>
             </plugins>
         </pluginManagement>
         <plugins>
@@ -477,6 +492,7 @@ Bundle-Category: jackrabbit
                 <scope>provided</scope>
             </dependency>
 
+            <!-- these are minimum version referenced in OSGi bundles, for embedding a newer version should be used -->
             <dependency>
                 <groupId>commons-io</groupId>
                 <artifactId>commons-io</artifactId>
@@ -600,6 +616,17 @@ Bundle-Category: jackrabbit
                             set system property also via argLine as only that allows late evaluation -->
                             <argLine>@{jacoco.command} -Djacoco.command=@{jacoco.command}</argLine>
                         </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>dependency-check</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.owasp</groupId>
+                        <artifactId>dependency-check-maven</artifactId>
                     </plugin>
                 </plugins>
             </build>

--- a/suppressions.xml
+++ b/suppressions.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0"?><!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  -->
+<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
+    <suppress>
+       <notes><![CDATA[
+       Oak GAV must not apply to JR2 CPE (like for 
+       ]]></notes>
+       <packageUrl regex="true">^pkg:maven/org\.apache\.jackrabbit/oak\-.*@.*$</packageUrl>
+       <cpe>cpe:/a:apache:jackrabbit</cpe>
+    </suppress>
+    <suppress>
+       <notes><![CDATA[
+       file name: org.apache.sling.jcr.api-2.0.4.jar does not suffer from CVE-2015-2944
+       ]]></notes>
+       <packageUrl regex="true">^pkg:maven/org\.apache\.sling/org\.apache\.sling\.jcr\.api@.*$</packageUrl>
+       <cve>CVE-2015-2944</cve>
+    </suppress>
+    <suppress>
+       <notes><![CDATA[
+       file name: h2-2.1.212.jar, only 1.4.197 is affected, see https://github.com/jeremylong/DependencyCheck/issues/4555
+       ]]></notes>
+       <packageUrl regex="true">^pkg:maven/com\.h2database/h2@.*$</packageUrl>
+       <vulnerabilityName>CVE-2018-14335</vulnerabilityName>
+    </suppress>
+    <suppress>
+       <notes><![CDATA[
+       file name: org.apache.sling.commons.classloader-1.2.2.jar
+       ]]></notes>
+       <packageUrl regex="true">^pkg:maven/org\.apache\.sling/org\.apache\.sling\.commons\.classloader@.*$</packageUrl>
+       <cpe>cpe:/a:apache-ssl:apache-ssl</cpe>
+    </suppress>
+    <suppress>
+       <notes><![CDATA[
+       false positive for Oak classes e.g. for CVE-2021-40690
+       ]]></notes>
+       <packageUrl regex="true">^pkg:maven/org\.apache\.jackrabbit/oak-.*@.*$</packageUrl>
+       <cpe>cpe:/a:apache:xml_security_for_java</cpe>
+    </suppress>
+</suppressions>

--- a/target-osgi-environment/pom.xml
+++ b/target-osgi-environment/pom.xml
@@ -73,6 +73,14 @@
                     </execution>
                 </executions>
             </plugin>
+            <!-- never do vulnerabilities check for any surrounding OSGi bundles provided by a distribution -->
+            <plugin>
+                <groupId>org.owasp</groupId>
+                <artifactId>dependency-check-maven</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 

--- a/vault-cli/pom.xml
+++ b/vault-cli/pom.xml
@@ -41,6 +41,17 @@
     <!-- B U I L D   D E F I N I T I O N                                        -->
     <!-- ====================================================================== -->
     <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.owasp</groupId>
+                    <artifactId>dependency-check-maven</artifactId>
+                    <configuration>
+                        <suppressionFile>${project.basedir}/../suppressions.xml</suppressionFile>
+                    </configuration>
+                </plugin>
+            </plugins>
+        </pluginManagement>
         <plugins>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
@@ -110,6 +121,27 @@
             </plugin>
         </plugins>
     </build>
+
+    <dependencyManagement>
+        <dependencies>
+            <!-- override minimum versions from parent with most recent backwards compatible versions -->
+            <dependency>
+                <groupId>commons-io</groupId>
+                <artifactId>commons-io</artifactId>
+                <version>2.11.0</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.httpcomponents</groupId>
+                <artifactId>httpmime</artifactId>
+                <version>4.5.13</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.httpcomponents</groupId>
+                <artifactId>httpclient</artifactId>
+                <version>4.5.13</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
     <!-- ====================================================================== -->
     <!-- D E P E N D E N C I E S                                                -->

--- a/vault-core/pom.xml
+++ b/vault-core/pom.xml
@@ -60,6 +60,18 @@
                         </execution>
                     </executions>
                 </plugin>
+                <plugin>
+                    <groupId>org.owasp</groupId>
+                    <artifactId>dependency-check-maven</artifactId>
+                    <configuration>
+                        <suppressionFile>${project.basedir}/../suppressions.xml</suppressionFile>
+                        <!-- only check embedded dependencies, therefore exclude all external dependencies with vulnerabilities (provided by the container) -->
+                        <excludes>
+                            <exlude>*:commons-io</exlude>
+                            <exlude>*:httpclient</exlude>
+                        </excludes>
+                    </configuration>
+                </plugin>
             </plugins>
         </pluginManagement>
         <plugins>
@@ -241,7 +253,7 @@
         <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
-            <version>2.0.206</version>
+            <version>2.1.212</version>
             <scope>provided</scope>
         </dependency>
         <!-- test deps -->

--- a/vault-davex/pom.xml
+++ b/vault-davex/pom.xml
@@ -87,4 +87,23 @@
             <artifactId>slf4j-api</artifactId>
         </dependency>
     </dependencies>
+    
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.owasp</groupId>
+                    <artifactId>dependency-check-maven</artifactId>
+                    <configuration>
+                        <suppressionFile>${project.basedir}/../suppressions.xml</suppressionFile>
+                        <!-- only check embedded dependencies, therefore exclude all external dependencies with vulnerabilities (provided by the container) -->
+                        <excludes>
+                            <exlude>*:commons-io</exlude>
+                            <exlude>*:httpclient</exlude>
+                        </excludes>
+                    </configuration>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+    </build>
 </project>

--- a/vault-hook-example/pom.xml
+++ b/vault-hook-example/pom.xml
@@ -92,19 +92,14 @@
         <dependency>
             <groupId>javax.jcr</groupId>
             <artifactId>jcr</artifactId>
-            <optional>true</optional>
+            <scope>provided</scope>
         </dependency>
 
-        <!-- SLF4j / Log4j -->
+        <!-- SLF4j -->
         <dependency>
             <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-log4j12</artifactId>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
-            <groupId>log4j</groupId>
-            <artifactId>log4j</artifactId>
-            <optional>true</optional>
+            <artifactId>slf4j-api</artifactId>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
 </project>

--- a/vault-hook-externalclass-test/pom.xml
+++ b/vault-hook-externalclass-test/pom.xml
@@ -91,26 +91,20 @@
         <dependency>
             <groupId>javax.jcr</groupId>
             <artifactId>jcr</artifactId>
-            <optional>true</optional>
+            <scope>provided</scope>
         </dependency>
 
-        <!-- SLF4j / Log4j -->
+        <!-- SLF4j -->
         <dependency>
             <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-log4j12</artifactId>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
-            <groupId>log4j</groupId>
-            <artifactId>log4j</artifactId>
-            <optional>true</optional>
+            <artifactId>slf4j-api</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.sling</groupId>
             <artifactId>org.apache.sling.api</artifactId>
-            <version>2.3.0</version>
+            <version>2.16.4</version>
             <scope>provided</scope>
-            <optional>true</optional>
         </dependency>
     </dependencies>
 </project>

--- a/vault-rcp/pom.xml
+++ b/vault-rcp/pom.xml
@@ -43,6 +43,24 @@
     <!-- B U I L D                                                             -->
     <!-- ====================================================================== -->
     <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.owasp</groupId>
+                    <artifactId>dependency-check-maven</artifactId>
+                    <configuration>
+                        <suppressionFile>${project.basedir}/../suppressions.xml</suppressionFile>
+                        <!-- only check embedded dependencies, therefore exclude all external dependencies with vulnerabilities (provided by the container) -->
+                        <excludes>
+                            <exlude>*:commons-io</exlude>
+                            <exlude>*:httpclient</exlude>
+                            <exlude>*:jackson-core</exlude>
+                            <exlude>*:jackson-databind</exlude>
+                        </excludes>
+                    </configuration>
+                </plugin>
+            </plugins>
+        </pluginManagement>
         <plugins>
             <plugin>
                 <groupId>org.apache.sling</groupId>
@@ -137,7 +155,7 @@
         <dependency>
             <groupId>org.apache.sling</groupId>
             <artifactId>org.apache.sling.api</artifactId>
-            <version>2.2.0</version>
+            <version>2.16.4</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/vault-sync/pom.xml
+++ b/vault-sync/pom.xml
@@ -45,6 +45,22 @@
     <!-- B U I L D   D E F I N I T I O N                                        -->
     <!-- ====================================================================== -->
     <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.owasp</groupId>
+                    <artifactId>dependency-check-maven</artifactId>
+                    <configuration>
+                        <suppressionFile>${project.basedir}/../suppressions.xml</suppressionFile>
+                        <!-- only check embedded dependencies, therefore exclude all external dependencies with vulnerabilities (provided by the container) -->
+                        <excludes>
+                            <exlude>*:commons-io</exlude>
+                            <exlude>*:guava</exlude>
+                        </excludes>
+                    </configuration>
+                </plugin>
+            </plugins>
+        </pluginManagement>
         <plugins>
             <plugin>
                 <groupId>org.apache.sling</groupId>

--- a/vault-validation/pom.xml
+++ b/vault-validation/pom.xml
@@ -40,6 +40,22 @@
     </properties>
 
     <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.owasp</groupId>
+                    <artifactId>dependency-check-maven</artifactId>
+                    <configuration>
+                        <suppressionFile>${project.basedir}/../suppressions.xml</suppressionFile>
+                        <!-- only check embedded dependencies, therefore exclude all external dependencies with vulnerabilities (provided by the container) -->
+                        <excludes>
+                            <exlude>*:commons-io</exlude>
+                            <exlude>*:httpclient</exlude>
+                        </excludes>
+                    </configuration>
+                </plugin>
+            </plugins>
+        </pluginManagement>
         <plugins>
             <!-- ====================================================================== -->
             <!-- R A T  P L U G I N                                                    -->
@@ -140,12 +156,45 @@
             <scope>provided</scope>
         </dependency>
 
-        <!-- only used for the constants, not necessary at run time -->
+        <!-- Oak dependencies only used for the constants, not necessary at run time (due to inlining) -->
         <dependency>
             <groupId>org.apache.jackrabbit</groupId>
             <artifactId>oak-core</artifactId>
             <version>${oak.version}</version>
             <optional>true</optional>
+            <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                  <groupId>*</groupId>
+                  <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.jackrabbit</groupId>
+            <artifactId>oak-security-spi</artifactId>
+            <version>${oak.version}</version>
+            <optional>true</optional>
+            <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                  <groupId>*</groupId>
+                  <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.jackrabbit</groupId>
+            <artifactId>oak-core-spi</artifactId>
+            <version>${oak.version}</version>
+            <optional>true</optional>
+            <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                  <groupId>*</groupId>
+                  <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>

--- a/vault-vlt/pom.xml
+++ b/vault-vlt/pom.xml
@@ -89,4 +89,23 @@
         </dependency>
     </dependencies>
 
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.owasp</groupId>
+                    <artifactId>dependency-check-maven</artifactId>
+                    <configuration>
+                        <suppressionFile>${project.basedir}/../suppressions.xml</suppressionFile>
+                        <!-- only check embedded dependencies, therefore exclude all external dependencies with vulnerabilities (provided by the container) -->
+                        <excludes>
+                            <exlude>*:commons-io</exlude>
+                            <exlude>*:httpclient</exlude>
+                            <exlude>*:log4j</exlude>
+                        </excludes>
+                    </configuration>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+    </build>
 </project>


### PR DESCRIPTION
Add OWASP dependency checker to all modules
Exclude external (e.g. OSGi) dependencies from being checked
Clean up some dependencies