### PR TITLE
JCRVLT-637: fix support for non-docview files with additional properties

### DIFF
--- a/vault-validation/src/main/java/org/apache/jackrabbit/vault/validation/ValidationExecutor.java
+++ b/vault-validation/src/main/java/org/apache/jackrabbit/vault/validation/ValidationExecutor.java
@@ -309,10 +309,13 @@ public final class ValidationExecutor {
                                 enrichedMessages.addAll(ValidationViolation.wrapMessages(entry.getKey(), messages, filePath, basePath, null, 0, 0));
                             }
                         } 
+
                         // only do it if we haven't collected node paths from a previous run
-                        if (nodePathsAndLineNumbers.isEmpty()) {
-                            // convert file name to node path
-                            String nodePath = filePathToNodePath(filePath);
+                        String nodePath = filePathToNodePath(filePath);
+                        boolean treatedAsBinaryFile = nodePathsAndLineNumbers.size() == 1 &&
+                            nodePathsAndLineNumbers.getOrDefault(nodePath, Integer.MIN_VALUE) == 0;
+
+                        if (nodePathsAndLineNumbers.isEmpty() || treatedAsBinaryFile) {
                             log.debug("Found non-docview node '{}'", nodePath);
                             isDocViewXml = false;
                             nodePathsAndLineNumbers.put(nodePath, 0);

--- a/vault-validation/src/test/java/org/apache/jackrabbit/vault/validation/ReturnNodeAndLineNumberAnswer.java
+++ b/vault-validation/src/test/java/org/apache/jackrabbit/vault/validation/ReturnNodeAndLineNumberAnswer.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.jackrabbit.vault.validation;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+
+class ReturnNodeAndLineNumberAnswer<T extends Collection<?>> implements Answer<T> {
+
+    private final String nodePath;
+    private final int lineNumber;
+    private final T returnValue;
+
+    public ReturnNodeAndLineNumberAnswer(String nodePath, int lineNumber) {
+        this(nodePath, lineNumber, (T) Collections.emptyList());
+    }
+
+    public ReturnNodeAndLineNumberAnswer(String nodePath, int lineNumber, T returnValue) {
+        this.nodePath = nodePath;
+        this.lineNumber = lineNumber;
+        this.returnValue = returnValue;
+    }
+
+    @Override
+    public T answer(InvocationOnMock invocationOnMock) {
+        Map nodePathsAndLineNumbers = invocationOnMock.getArgument(3, Map.class);
+        nodePathsAndLineNumbers.put(nodePath, lineNumber);
+        return returnValue;
+    }
+}

--- a/vault-validation/src/test/java/org/apache/jackrabbit/vault/validation/ValidationExecutorTest.java
+++ b/vault-validation/src/test/java/org/apache/jackrabbit/vault/validation/ValidationExecutorTest.java
@@ -198,6 +198,25 @@ public class ValidationExecutorTest {
         }
     }
 
+    /*
+     * JCRVLT-637: verify that when the DocumentViewXmlValidator returns the binary file as nodePath with lineNumber 0 to the
+     * ValidationExecutor, {@code isDocViewXml} is set to false
+     */
+    @Test
+    public void testGenericJcrDataWithBinaryFileDetected()
+        throws URISyntaxException, IOException, SAXException, ParserConfigurationException, ConfigurationException {
+        Mockito.when(genericJcrDataValidator.shouldValidateJcrData(Mockito.any(), Mockito.any())).thenReturn(true);
+        ReturnNodeAndLineNumberAnswer<Collection<ValidationMessage>> answer = new ReturnNodeAndLineNumberAnswer<>("/apps/genericfile.xml", 0);
+        Mockito.when(genericJcrDataValidator.validateJcrData(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any())).thenAnswer(answer);
+        try (InputStream input = this.getClass().getResourceAsStream("/simple-package/jcr_root/apps/genericfile.xml")) {
+            Collection<ValidationViolation> messages = validate(input, executor, Paths.get(""), "apps/genericfile.xml", false);
+            MatcherAssert.assertThat(messages, AnyValidationViolationMessageMatcher.noValidationViolationMessageInCollection());
+            Path expectedPath = Paths.get("apps/genericfile.xml");
+            NodeContext expectedNodeContext = new NodeContextImpl("/apps/genericfile.xml", expectedPath,  Paths.get(""));
+            Mockito.verify(jcrPathValidator).validateJcrPath(expectedNodeContext, false, false);
+        }
+    }
+
     @Test
     public void testGenericJcrDataWithNoGenericJcrDataValidator()
             throws URISyntaxException, IOException, SAXException, ParserConfigurationException, ConfigurationException {

--- a/vault-validation/src/test/resources/valid-packages/application-package/jcr_root/apps/genericfile.xml.dir/.content.xml
+++ b/vault-validation/src/test/resources/valid-packages/application-package/jcr_root/apps/genericfile.xml.dir/.content.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  -->
+<jcr:root xmlns:jcr="http://www.jcp.org/jcr/1.0"
+    jcr:primaryType="nt:file">
+    <jcr:content
+        jcr:primaryType="nt:resource"
+        jcr:mixinTypes="[mix:language]"
+        jcr:language="en">
+    </jcr:content>
+</jcr:root>


### PR DESCRIPTION
The DocumentViewParserValidator returns a binary file back to the ValidationExecutor as node path with a line number of 0.
The ValidationExecutor considers this state as docview xml case.

With this change the ValidationExecutor checks the returned nodePaths and lineNubmers and if only one nodePath (the file) is returned with lineNumber 0, it handles it the same way as if nothing would have been returned (existing logic).