### PR TITLE
JCRVLT-647 restore old save() interval after failed save() attempts

### DIFF
--- a/vault-core/src/main/java/org/apache/jackrabbit/vault/fs/io/AutoSave.java
+++ b/vault-core/src/main/java/org/apache/jackrabbit/vault/fs/io/AutoSave.java
@@ -170,8 +170,8 @@ public class AutoSave {
             }
             if (!saveWithBackoff(session, isIntermediate)) {
                 // either retry after some more nodes have been modified or after throttle 
-                // retry with next save() after another 10 nodes have been modified
-                failedSaveThreshold = 10;
+                // retry with next save() after more nodes have been modified
+                failedSaveThreshold = threshold;
                 log.warn("Retry auto-save after {} more modified nodes", failedSaveThreshold);
             } else {
                 lastSave = numModified;

--- a/vault-core/src/main/java/org/apache/jackrabbit/vault/fs/io/AutoSave.java
+++ b/vault-core/src/main/java/org/apache/jackrabbit/vault/fs/io/AutoSave.java
@@ -263,7 +263,8 @@ public class AutoSave {
 
     @Override
     public String toString() {
-        return String.valueOf(threshold);
+        return "AutoSave [numModified=" + numModified + ", lastSave=" + lastSave + ", threshold=" + threshold + ", failedSaveThreshold="
+                + failedSaveThreshold + ", dryRun=" + dryRun + "]";
     }
 
 }

--- a/vault-core/src/main/java/org/apache/jackrabbit/vault/fs/io/AutoSave.java
+++ b/vault-core/src/main/java/org/apache/jackrabbit/vault/fs/io/AutoSave.java
@@ -172,7 +172,7 @@ public class AutoSave {
                 // either retry after some more nodes have been modified or after throttle 
                 // retry with next save() after more nodes have been modified
                 failedSaveThreshold += threshold;
-                log.warn("Retry auto-save after {} more modified nodes", failedSaveThreshold);
+                log.warn("Retry auto-save after {} more modified nodes", threshold);
             } else {
                 lastSave = numModified;
                 failedSaveThreshold = 0;

--- a/vault-core/src/main/java/org/apache/jackrabbit/vault/fs/io/AutoSave.java
+++ b/vault-core/src/main/java/org/apache/jackrabbit/vault/fs/io/AutoSave.java
@@ -171,8 +171,8 @@ public class AutoSave {
             if (!saveWithBackoff(session, isIntermediate)) {
                 // either retry after some more nodes have been modified or after throttle 
                 // retry with next save() after more nodes have been modified
-                failedSaveThreshold += threshold;
-                log.warn("Retry auto-save after {} more modified nodes", threshold);
+                failedSaveThreshold = (diff - threshold) + 10; // 10 more
+                log.warn("Retry auto-save after {} more modified nodes", 10);
             } else {
                 lastSave = numModified;
                 failedSaveThreshold = 0;
@@ -213,7 +213,7 @@ public class AutoSave {
     }
 
     boolean isPotentiallyTransientException(RepositoryException e) {
-        if (e instanceof InvalidItemStateException || e instanceof ConstraintViolationException) {
+        if (e instanceof ConstraintViolationException) {
             return true;
         }
         return false;

--- a/vault-core/src/main/java/org/apache/jackrabbit/vault/fs/io/AutoSave.java
+++ b/vault-core/src/main/java/org/apache/jackrabbit/vault/fs/io/AutoSave.java
@@ -171,7 +171,7 @@ public class AutoSave {
             if (!saveWithBackoff(session, isIntermediate)) {
                 // either retry after some more nodes have been modified or after throttle 
                 // retry with next save() after more nodes have been modified
-                failedSaveThreshold = threshold;
+                failedSaveThreshold += threshold;
                 log.warn("Retry auto-save after {} more modified nodes", failedSaveThreshold);
             } else {
                 lastSave = numModified;

--- a/vault-core/src/main/java/org/apache/jackrabbit/vault/fs/io/Importer.java
+++ b/vault-core/src/main/java/org/apache/jackrabbit/vault/fs/io/Importer.java
@@ -466,7 +466,7 @@ public class Importer {
             }
         }
         cpAutosave = autoSave.copy();
-        LinkedList<TxInfo> skipList = new LinkedList<TxInfo>();
+        LinkedList<TxInfo> skipList = new LinkedList<>();
         while (recoveryRetryCounter++ < 10) {
             try {
                 commit(session, root, skipList);

--- a/vault-core/src/test/java/org/apache/jackrabbit/vault/fs/io/AutoSaveTest.java
+++ b/vault-core/src/test/java/org/apache/jackrabbit/vault/fs/io/AutoSaveTest.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jackrabbit.vault.fs.io;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import javax.jcr.AccessDeniedException;
+import javax.jcr.InvalidItemStateException;
+import javax.jcr.ItemExistsException;
+import javax.jcr.ReferentialIntegrityException;
+import javax.jcr.RepositoryException;
+import javax.jcr.Session;
+import javax.jcr.lock.LockException;
+import javax.jcr.nodetype.ConstraintViolationException;
+import javax.jcr.nodetype.NoSuchNodeTypeException;
+import javax.jcr.version.VersionException;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class AutoSaveTest {
+
+    @Mock
+    private Session session;
+
+    @Test
+    public void testNeedsSave() {
+        AutoSave autoSave = new AutoSave(100);
+        assertFalse(autoSave.needsSave());
+        autoSave.modified(99);
+        // still below threshold
+        assertFalse(autoSave.needsSave());
+        autoSave.modified(1);
+        assertTrue(autoSave.needsSave());
+    }
+
+    @Test
+    public void testNeedsSaveAfterFailedSave() throws AccessDeniedException, ItemExistsException, ReferentialIntegrityException, ConstraintViolationException, InvalidItemStateException, VersionException, LockException, NoSuchNodeTypeException, RepositoryException {
+        Mockito.doThrow(new ConstraintViolationException("Forced exception")).when(session).save();
+        AutoSave autoSave = new AutoSave(100);
+        autoSave.modified(100);
+        assertTrue(autoSave.needsSave());
+        // failed save attempt
+        // need a retry after 100 more nodes
+        autoSave.save(session);
+        assertFalse(autoSave.needsSave());
+        autoSave.modified(1);
+        assertFalse(autoSave.needsSave());
+        autoSave.modified(99);
+        assertTrue(autoSave.needsSave());
+        Mockito.reset(session);
+        // retry successfull
+        autoSave.save(session);
+        assertFalse(autoSave.needsSave());
+        autoSave.modified(10);
+        assertFalse(autoSave.needsSave());
+        autoSave.modified(90);
+        // next regular save after 100 more nodes
+        assertTrue(autoSave.needsSave());
+    }
+}

--- a/vault-core/src/test/java/org/apache/jackrabbit/vault/fs/io/AutoSaveTest.java
+++ b/vault-core/src/test/java/org/apache/jackrabbit/vault/fs/io/AutoSaveTest.java
@@ -68,6 +68,12 @@ public class AutoSaveTest {
         assertFalse(autoSave.needsSave());
         autoSave.modified(99);
         assertTrue(autoSave.needsSave());
+        // 2nd failed attempt
+        autoSave.save(session);
+        assertFalse(autoSave.needsSave());
+        autoSave.modified(1);
+        assertFalse(autoSave.needsSave());
+        autoSave.modified(99);
         Mockito.reset(session);
         // retry successfull
         autoSave.save(session);

--- a/vault-core/src/test/java/org/apache/jackrabbit/vault/fs/io/AutoSaveTest.java
+++ b/vault-core/src/test/java/org/apache/jackrabbit/vault/fs/io/AutoSaveTest.java
@@ -66,14 +66,14 @@ public class AutoSaveTest {
         assertFalse(autoSave.needsSave());
         autoSave.modified(1);
         assertFalse(autoSave.needsSave());
-        autoSave.modified(99);
+        autoSave.modified(20);
         assertTrue(autoSave.needsSave());
         // 2nd failed attempt
         autoSave.save(session);
         assertFalse(autoSave.needsSave());
-        autoSave.modified(1);
+        autoSave.modified(9);
         assertFalse(autoSave.needsSave());
-        autoSave.modified(99);
+        autoSave.modified(1);
         Mockito.reset(session);
         // retry successfull
         autoSave.save(session);


### PR DESCRIPTION
Verify that counters behave correctly