### PR TITLE
JCRVLT-650: apply default id conflict policy as late as possible

### DIFF
--- a/vault-core/src/main/java/org/apache/jackrabbit/vault/fs/io/Importer.java
+++ b/vault-core/src/main/java/org/apache/jackrabbit/vault/fs/io/Importer.java
@@ -47,6 +47,7 @@ import org.apache.jackrabbit.spi.commons.namespace.NamespaceResolver;
 import org.apache.jackrabbit.spi.commons.namespace.SessionNamespaceResolver;
 import org.apache.jackrabbit.vault.fs.api.Artifact;
 import org.apache.jackrabbit.vault.fs.api.ArtifactType;
+import org.apache.jackrabbit.vault.fs.api.IdConflictPolicy;
 import org.apache.jackrabbit.vault.fs.api.ImportInfo;
 import org.apache.jackrabbit.vault.fs.api.ImportMode;
 import org.apache.jackrabbit.vault.fs.api.NodeNameList;
@@ -272,7 +273,7 @@ public class Importer {
     /**
      * list of intermediate infos that were removed since the last auto save
      */
-    private Map<String, TxInfo> removedIntermediates = new LinkedHashMap<String, TxInfo>();
+    private Map<String, TxInfo> removedIntermediates = new LinkedHashMap<>();
 
     private final boolean isStrict;
     private final boolean isStrictByDefault;
@@ -291,10 +292,17 @@ public class Importer {
     }
 
     public Importer(ImportOptions opts, boolean isStrictByDefault, boolean overwritePrimaryTypesOfFoldersByDefault) {
+        this(opts, isStrictByDefault, overwritePrimaryTypesOfFoldersByDefault, null);
+    }
+
+    public Importer(ImportOptions opts, boolean isStrictByDefault, boolean overwritePrimaryTypesOfFoldersByDefault, IdConflictPolicy defaultIdConflictPolicy) {
         this.opts = opts;
         this.isStrict = opts.isStrict(isStrictByDefault);
         this.isStrictByDefault = isStrictByDefault;
         this.overwritePrimaryTypesOfFoldersByDefault = overwritePrimaryTypesOfFoldersByDefault;
+        if (!this.opts.hasIdConflictPolicyBeenSet()) {
+            this.opts.setIdConflictPolicy(defaultIdConflictPolicy);
+        }
     }
 
     public ImportOptions getOptions() {

--- a/vault-core/src/main/java/org/apache/jackrabbit/vault/fs/io/Importer.java
+++ b/vault-core/src/main/java/org/apache/jackrabbit/vault/fs/io/Importer.java
@@ -279,22 +279,49 @@ public class Importer {
     private final boolean isStrictByDefault;
     private final boolean overwritePrimaryTypesOfFoldersByDefault;
 
+    /**
+     * Default constructor neither setting specific import options nor defaults.
+     */
     public Importer() {
          this(new ImportOptions(), false, true);
     }
 
+    /**
+     * Constructor which is not setting default options.
+     * @param opts
+     * @see #Importer(ImportOptions, boolean, boolean, IdConflictPolicy)
+     */
     public Importer(ImportOptions opts) {
         this(opts, false);
     }
 
+    /**
+     * Shortcut for {@link Importer#Importer(ImportOptions, boolean, boolean, IdConflictPolicy)} with no default id conflict policy.
+     * Also primary types of existing nodes are always overwritten.
+     * @param opts the import options to use during {@link #run(Archive, Node)} or {@link #run(Archive, Session, String)}
+     * @param isStrictByDefault is true if packages should be installed in strict mode by default (if not set otherwise in {@code opts})
+     */
     public Importer(ImportOptions opts, boolean isStrictByDefault) {
         this(opts, isStrictByDefault, true);
     }
 
+    /**
+     * Shortcut for {@link Importer#Importer(ImportOptions, boolean, boolean, IdConflictPolicy)} with no default id conflict policy.
+     * @param opts the import options to use during {@link #run(Archive, Node)} or {@link #run(Archive, Session, String)}
+     * @param isStrictByDefault is true if packages should be installed in strict mode by default (if not set otherwise in {@code opts})
+     * @param overwritePrimaryTypesOfFoldersByDefault if folder aggregates' JCR primary type should be changed if the node is already existing or not
+     */
     public Importer(ImportOptions opts, boolean isStrictByDefault, boolean overwritePrimaryTypesOfFoldersByDefault) {
         this(opts, isStrictByDefault, overwritePrimaryTypesOfFoldersByDefault, null);
     }
 
+    /**
+     * Constructor setting both specific import options as well as some defaults for options not set.
+     * @param opts the import options to use during {@link #run(Archive, Node)} or {@link #run(Archive, Session, String)}
+     * @param isStrictByDefault is true if packages should be installed in strict mode by default (if not set otherwise in {@code opts})
+     * @param overwritePrimaryTypesOfFoldersByDefault if folder aggregates' JCR primary type should be changed if the node is already existing or not
+     * @param defaultIdConflictPolicy the default {@link IdConflictPolicy} to use if no policy is set in {@code opts}. May be {@code null}.
+     */
     public Importer(ImportOptions opts, boolean isStrictByDefault, boolean overwritePrimaryTypesOfFoldersByDefault, IdConflictPolicy defaultIdConflictPolicy) {
         this.opts = opts;
         this.isStrict = opts.isStrict(isStrictByDefault);

--- a/vault-core/src/main/java/org/apache/jackrabbit/vault/packaging/impl/JcrPackageImpl.java
+++ b/vault-core/src/main/java/org/apache/jackrabbit/vault/packaging/impl/JcrPackageImpl.java
@@ -353,7 +353,7 @@ public class JcrPackageImpl implements JcrPackage {
 
     private void extract(ImportOptions options, boolean createSnapshot, boolean replaceSnapshot)
             throws RepositoryException, PackageException, IOException {
-        extract(new HashSet<PackageId>(), options, createSnapshot, replaceSnapshot);
+        extract(new HashSet<>(), options, createSnapshot, replaceSnapshot);
     }
 
     /**
@@ -386,19 +386,15 @@ public class JcrPackageImpl implements JcrPackage {
             // MAX_VALUE disables saving completely, therefore we have to use a lower value!
             opts.setAutoSaveThreshold(Integer.MAX_VALUE - 1);
         }
-        if (!opts.hasIdConflictPolicyBeenSet()) {
-            opts.setIdConflictPolicy(mgr.getDefaultIdConflictPolicy());
-        }
-        opts.setIdConflictPolicy(mgr.getDefaultIdConflictPolicy());
         InstallContextImpl ctx = pack.prepareExtract(node.getSession(), opts, mgr.getSecurityConfig(), mgr.isStrictByDefault(),
-                mgr.overwritePrimaryTypesOfFoldersByDefault());
+                mgr.overwritePrimaryTypesOfFoldersByDefault(), mgr.getDefaultIdConflictPolicy());
         JcrPackage snap = null;
         if (!opts.isDryRun() && createSnapshot) {
             ExportOptions eOpts = new ExportOptions();
             eOpts.setListener(opts.getListener());
             snap = snapshot(eOpts, replaceSnapshot, opts.getAccessControlHandling());
         }
-        List<String> subPackages = new ArrayList<String>();
+        List<String> subPackages = new ArrayList<>();
         pack.extract(ctx, subPackages);
         if (def != null && !opts.isDryRun()) {
             def.touchLastUnpacked();
@@ -417,7 +413,8 @@ public class JcrPackageImpl implements JcrPackage {
                     try {
                         p.tryUnwrap();
                     } catch (Exception e) {
-                        log.info("Sub package {} not valid: " + e, path);
+                        log.info("Sub package {} not valid: {}", path, e.getMessage());
+                        log.debug("Sub package {} not valid", path, e);
                     }
                 }
                 if (p.isValid()) {

--- a/vault-core/src/main/java/org/apache/jackrabbit/vault/packaging/impl/ZipVaultPackage.java
+++ b/vault-core/src/main/java/org/apache/jackrabbit/vault/packaging/impl/ZipVaultPackage.java
@@ -187,7 +187,10 @@ public class ZipVaultPackage extends PackagePropertiesImpl implements VaultPacka
      *
      * @param session repository session
      * @param opts import options
-     * @param defaultIdConflictPolicy 
+     * @param securityConfig the security configuration determining e.g. the install hook limitations
+     * @param isStrictByDefault is true if packages should be installed in strict mode by default (if not set otherwise in {@code opts})
+     * @param overwritePrimaryTypesOfFoldersByDefault if folder aggregates' JCR primary type should be changed if the node is already existing or not
+     * @param defaultIdConflictPolicy the default {@link IdConflictPolicy} to use if no policy is set in {@code opts}. May be {@code null}.
      *
      * @throws javax.jcr.RepositoryException if a repository error during installation occurs.
      * @throws org.apache.jackrabbit.vault.packaging.PackageException if an error during packaging occurs

--- a/vault-core/src/main/java/org/apache/jackrabbit/vault/packaging/impl/ZipVaultPackage.java
+++ b/vault-core/src/main/java/org/apache/jackrabbit/vault/packaging/impl/ZipVaultPackage.java
@@ -172,7 +172,7 @@ public class ZipVaultPackage extends PackagePropertiesImpl implements VaultPacka
      * {@inheritDoc}
      */
     public void extract(Session session, ImportOptions opts) throws RepositoryException, PackageException {
-        extract(session, opts, new AbstractPackageRegistry.SecurityConfig(null, null), false, true);
+        extract(session, opts, new AbstractPackageRegistry.SecurityConfig(null, null), false, true, null);
     }
 
     /**

--- a/vault-core/src/main/java/org/apache/jackrabbit/vault/packaging/impl/ZipVaultPackage.java
+++ b/vault-core/src/main/java/org/apache/jackrabbit/vault/packaging/impl/ZipVaultPackage.java
@@ -28,6 +28,7 @@ import java.util.regex.PatternSyntaxException;
 import javax.jcr.RepositoryException;
 import javax.jcr.Session;
 
+import org.apache.jackrabbit.vault.fs.api.IdConflictPolicy;
 import org.apache.jackrabbit.vault.fs.config.MetaInf;
 import org.apache.jackrabbit.vault.fs.io.AccessControlHandling;
 import org.apache.jackrabbit.vault.fs.io.Archive;
@@ -163,8 +164,8 @@ public class ZipVaultPackage extends PackagePropertiesImpl implements VaultPacka
      * @throws RepositoryException if a repository error during installation occurs.
      */
     public void extract(Session session, ImportOptions opts, @NotNull AbstractPackageRegistry.SecurityConfig securityConfig,
-            boolean isStrict, boolean isOverwritePrimaryTypesOfFolders) throws PackageException, RepositoryException {
-        extract(prepareExtract(session, opts, securityConfig, isStrict, isOverwritePrimaryTypesOfFolders), null);
+            boolean isStrict, boolean isOverwritePrimaryTypesOfFolders, IdConflictPolicy defaultIdConflictPolicy) throws PackageException, RepositoryException {
+        extract(prepareExtract(session, opts, securityConfig, isStrict, isOverwritePrimaryTypesOfFolders,defaultIdConflictPolicy), null);
     }
 
     /**
@@ -186,6 +187,7 @@ public class ZipVaultPackage extends PackagePropertiesImpl implements VaultPacka
      *
      * @param session repository session
      * @param opts import options
+     * @param defaultIdConflictPolicy 
      *
      * @throws javax.jcr.RepositoryException if a repository error during installation occurs.
      * @throws org.apache.jackrabbit.vault.packaging.PackageException if an error during packaging occurs
@@ -194,7 +196,7 @@ public class ZipVaultPackage extends PackagePropertiesImpl implements VaultPacka
      */
     protected InstallContextImpl prepareExtract(Session session, ImportOptions opts,
             @NotNull AbstractPackageRegistry.SecurityConfig securityConfig, boolean isStrictByDefault,
-            boolean overwritePrimaryTypesOfFoldersByDefault) throws PackageException, RepositoryException {
+            boolean overwritePrimaryTypesOfFoldersByDefault, IdConflictPolicy defaultIdConflictPolicy) throws PackageException, RepositoryException {
         if (!isValid()) {
             throw new IllegalStateException("Package not valid.");
         }
@@ -214,7 +216,7 @@ public class ZipVaultPackage extends PackagePropertiesImpl implements VaultPacka
                 opts.setAutoSaveThreshold(Integer.MAX_VALUE - 1);
             }
     
-            Importer importer = new Importer(opts, isStrictByDefault, overwritePrimaryTypesOfFoldersByDefault);
+            Importer importer = new Importer(opts, isStrictByDefault, overwritePrimaryTypesOfFoldersByDefault, defaultIdConflictPolicy);
             AccessControlHandling ac = getACHandling();
             if (opts.getAccessControlHandling() == null) {
                 opts.setAccessControlHandling(ac);

--- a/vault-core/src/main/java/org/apache/jackrabbit/vault/packaging/registry/impl/FSPackageRegistry.java
+++ b/vault-core/src/main/java/org/apache/jackrabbit/vault/packaging/registry/impl/FSPackageRegistry.java
@@ -631,7 +631,7 @@ public class FSPackageRegistry extends AbstractPackageRegistry {
                 
             }
             if (vltPkg instanceof ZipVaultPackage) {
-                ((ZipVaultPackage)vltPkg).extract(session, opts, getSecurityConfig(), isStrictByDefault(), overwritePrimaryTypesOfFoldersByDefault());
+                ((ZipVaultPackage)vltPkg).extract(session, opts, getSecurityConfig(), isStrictByDefault(), overwritePrimaryTypesOfFoldersByDefault(), getDefaultIdConflictPolicy());
                 dispatch(PackageEvent.Type.EXTRACT, pkg.getId(), null);
                 stateCache.updatePackageStatus(vltPkg.getId(), FSPackageStatus.EXTRACTED);
             } else {


### PR DESCRIPTION
fix incorrect overwrite of explicit policy
apply default also for FSPackages