### PR TITLE
[SECURITY] Fix Temporary File Information Disclosure Vulnerability


### DIFF
--- a/vault-core/src/main/java/org/apache/jackrabbit/vault/fs/impl/PropertyValueArtifact.java
+++ b/vault-core/src/main/java/org/apache/jackrabbit/vault/fs/impl/PropertyValueArtifact.java
@@ -22,6 +22,7 @@ import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.Files;
 import java.util.Collection;
 import java.util.LinkedList;
 
@@ -162,7 +163,7 @@ public class PropertyValueArtifact extends AbstractArtifact implements ExportArt
             // ensure caching of content type
             getContentType();
             // copy value to temp file
-            tmpFile = File.createTempFile("jcrfs", "dat");
+            tmpFile = Files.createTempFile("jcrfs", "dat").toFile();
             tmpFile.setLastModified(getLastModified());
             tmpFile.deleteOnExit();
             try (FileOutputStream out = new FileOutputStream(tmpFile);

--- a/vault-core/src/main/java/org/apache/jackrabbit/vault/fs/impl/VaultFileOutputImpl.java
+++ b/vault-core/src/main/java/org/apache/jackrabbit/vault/fs/impl/VaultFileOutputImpl.java
@@ -21,6 +21,7 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.nio.file.Files;
 
 import javax.jcr.RepositoryException;
 
@@ -61,7 +62,7 @@ public class VaultFileOutputImpl implements VaultFileOutput {
         if (out != null) {
             throw new IOException("Output stream already obtained.");
         }
-        tmpFile = File.createTempFile("vltfs", ".tmp");
+        tmpFile = Files.createTempFile("vltfs", ".tmp").toFile();
         tmpFile.deleteOnExit();
         out = new FileOutputStream(tmpFile);
         return out;

--- a/vault-core/src/main/java/org/apache/jackrabbit/vault/fs/io/ZipStreamArchive.java
+++ b/vault-core/src/main/java/org/apache/jackrabbit/vault/fs/io/ZipStreamArchive.java
@@ -22,6 +22,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.RandomAccessFile;
+import java.nio.file.Files;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedHashMap;
@@ -232,7 +233,7 @@ public class ZipStreamArchive extends AbstractArchive {
             pos += read;
             if (pos == decompressed.length) {
                 // switch to raf
-                tmpFile = File.createTempFile("__vlttmpbuffer", ".dat");
+                tmpFile = Files.createTempFile("__vlttmpbuffer", ".dat").toFile();
                 raf = new RandomAccessFile(tmpFile, "rw");
                 raf.write(decompressed);
                 decompressed = null;

--- a/vault-core/src/main/java/org/apache/jackrabbit/vault/packaging/impl/JcrPackageImpl.java
+++ b/vault-core/src/main/java/org/apache/jackrabbit/vault/packaging/impl/JcrPackageImpl.java
@@ -21,6 +21,7 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -321,7 +322,7 @@ public class JcrPackageImpl implements JcrPackage {
                     throw new IOException("Error while reading stream", e);
                 }
             } else {
-                File tmpFile = File.createTempFile("vaultpack", ".zip");
+                File tmpFile = Files.createTempFile("vaultpack", ".zip").toFile();
                 Binary bin = getData().getBinary();
                 try (FileOutputStream out = FileUtils.openOutputStream(tmpFile); 
                     InputStream in = bin.getStream()) {

--- a/vault-core/src/main/java/org/apache/jackrabbit/vault/packaging/impl/PackageManagerImpl.java
+++ b/vault-core/src/main/java/org/apache/jackrabbit/vault/packaging/impl/PackageManagerImpl.java
@@ -24,6 +24,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.URISyntaxException;
+import java.nio.file.Files;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
@@ -109,7 +110,7 @@ public class PackageManagerImpl implements PackageManager {
         boolean success = false;
         try {
             if (file == null) {
-                file = File.createTempFile("filevault", ".zip");
+                file = Files.createTempFile("filevault", ".zip").toFile();
                 isTmp = true;
             }
             out = FileUtils.openOutputStream(file);
@@ -176,7 +177,7 @@ public class PackageManagerImpl implements PackageManager {
         boolean isTmp = false;
         boolean success = false;
         if (file == null) {
-            file = File.createTempFile("filevault", ".zip");
+            file = Files.createTempFile("filevault", ".zip").toFile();
             isTmp = true;
         }
         try (OutputStream out = FileUtils.openOutputStream(file);){

--- a/vault-core/src/test/java/org/apache/jackrabbit/vault/fs/io/JarExporterTest.java
+++ b/vault-core/src/test/java/org/apache/jackrabbit/vault/fs/io/JarExporterTest.java
@@ -27,6 +27,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.Files;
 import java.util.Date;
 import java.util.zip.ZipException;
 
@@ -54,7 +55,7 @@ public class JarExporterTest {
     public void testEntriesWithSuppressedCompression() throws RepositoryException, IOException {
         Mocks m = new Mocks("org/apache/jackrabbit/vault/fs/io/JarExporter/testEntriesWithSuppressedCompression");
         for (int level : new int[] { NO_COMPRESSION, BEST_COMPRESSION, BEST_SPEED }) {
-            File target = File.createTempFile("testEntriesWithSuppressedCompression", ".zip", null);
+            File target = Files.createTempFile("testEntriesWithSuppressedCompression", ".zip").toFile();
             ZipStreamArchive archive = null;
             try {
                 JarExporter exporter = new JarExporter(target, level);

--- a/vault-core/src/test/java/org/apache/jackrabbit/vault/packaging/integration/ACEsAtRootIT.java
+++ b/vault-core/src/test/java/org/apache/jackrabbit/vault/packaging/integration/ACEsAtRootIT.java
@@ -21,6 +21,7 @@ import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.nio.file.Files;
 import java.security.Principal;
 import java.util.Properties;
 import java.util.zip.Deflater;
@@ -121,7 +122,7 @@ public class ACEsAtRootIT extends IntegrationTestBase {
         opts.setRootPath("/");
         opts.setCompressionLevel(Deflater.BEST_SPEED);
 
-        File tmpFile = File.createTempFile("vaulttest", ".zip");
+        File tmpFile = Files.createTempFile("vaulttest", ".zip").toFile();
         OutputStream os = new FileOutputStream(tmpFile);
         Session session = repository.login(new SimpleCredentials(userId, userPwd.toCharArray()));
         packMgr.assemble(admin, opts, os);

--- a/vault-core/src/test/java/org/apache/jackrabbit/vault/packaging/integration/EscapedExportIT.java
+++ b/vault-core/src/test/java/org/apache/jackrabbit/vault/packaging/integration/EscapedExportIT.java
@@ -20,6 +20,7 @@ package org.apache.jackrabbit.vault.packaging.integration;
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.util.Properties;
 
 import javax.jcr.Node;
@@ -113,7 +114,7 @@ public class EscapedExportIT extends IntegrationTestBase {
     }
 
     private void assembleAndReinstallPackage() throws IOException, PackageException, RepositoryException {
-        File pkgFile = File.createTempFile("vaulttest", ".zip");
+        File pkgFile = Files.createTempFile("vaulttest", ".zip").toFile();
 
         try {
             ExportOptions options = new ExportOptions();

--- a/vault-core/src/test/java/org/apache/jackrabbit/vault/packaging/integration/ExportWithQuotedPatternIT.java
+++ b/vault-core/src/test/java/org/apache/jackrabbit/vault/packaging/integration/ExportWithQuotedPatternIT.java
@@ -18,6 +18,7 @@ package org.apache.jackrabbit.vault.packaging.integration;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.util.Properties;
 import java.util.regex.Pattern;
 
@@ -79,7 +80,7 @@ public class ExportWithQuotedPatternIT extends IntegrationTestBase {
     private File assemblePackage(WorkspaceFilter filter)
             throws IOException, RepositoryException {
 
-        File tmpFile = File.createTempFile("vaulttest", ".zip");
+        File tmpFile = Files.createTempFile("vaulttest", ".zip").toFile();
 
         ExportOptions options = new ExportOptions();
         DefaultMetaInf meta = new DefaultMetaInf();

--- a/vault-core/src/test/java/org/apache/jackrabbit/vault/packaging/integration/FilteredPropertiesIT.java
+++ b/vault-core/src/test/java/org/apache/jackrabbit/vault/packaging/integration/FilteredPropertiesIT.java
@@ -23,6 +23,7 @@ import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.util.Properties;
 
 import javax.jcr.Node;
@@ -531,7 +532,7 @@ public class FilteredPropertiesIT extends IntegrationTestBase {
     private File assemblePackage(WorkspaceFilter filter)
             throws IOException, RepositoryException {
 
-        File tmpFile = File.createTempFile("vaulttest", ".zip");
+        File tmpFile = Files.createTempFile("vaulttest", ".zip").toFile();
         packMgr.assemble(admin, createExportOptions(filter), tmpFile).close();
         return tmpFile;
     }

--- a/vault-core/src/test/java/org/apache/jackrabbit/vault/packaging/integration/ManifestCreationExportIT.java
+++ b/vault-core/src/test/java/org/apache/jackrabbit/vault/packaging/integration/ManifestCreationExportIT.java
@@ -19,6 +19,7 @@ package org.apache.jackrabbit.vault.packaging.integration;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.util.Collections;
 import java.util.Properties;
 
@@ -58,7 +59,7 @@ public class ManifestCreationExportIT extends IntegrationTestBase {
         inf.setProperties(props);
 
         opts.setMetaInf(inf);
-        File tmpFile = File.createTempFile("e-vaulttest", ".zip");
+        File tmpFile = Files.createTempFile("e-vaulttest", ".zip").toFile();
         try (VaultPackage pkg = packMgr.assemble(admin, opts, tmpFile)) {
             String expected =
                     "Content-Package-Dependencies:foo:bar:[1.0,2.0)\n" +

--- a/vault-core/src/test/java/org/apache/jackrabbit/vault/packaging/integration/MappedExportIT.java
+++ b/vault-core/src/test/java/org/apache/jackrabbit/vault/packaging/integration/MappedExportIT.java
@@ -19,6 +19,7 @@ package org.apache.jackrabbit.vault.packaging.integration;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.util.Properties;
 
 import javax.jcr.RepositoryException;
@@ -58,7 +59,7 @@ public class MappedExportIT extends IntegrationTestBase {
         opts.setMetaInf(inf);
         opts.setMountPath("/tmp/foo");
         opts.setRootPath("/content/geometrixx");
-        File tmpFile = File.createTempFile("vaulttest", "zip");
+        File tmpFile = Files.createTempFile("vaulttest", "zip").toFile();
         VaultPackage pkg = packMgr.assemble(admin, opts, tmpFile);
 
         // check if entries are present

--- a/vault-core/src/test/java/org/apache/jackrabbit/vault/packaging/integration/NamespaceImportIT.java
+++ b/vault-core/src/test/java/org/apache/jackrabbit/vault/packaging/integration/NamespaceImportIT.java
@@ -22,6 +22,7 @@ import static org.junit.Assert.assertNotNull;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.util.Properties;
 
 import javax.jcr.NamespaceException;
@@ -107,7 +108,7 @@ public class NamespaceImportIT extends IntegrationTestBase {
         inf.setProperties(props);
         opts.setMetaInf(inf);
 
-        File tmpFile = File.createTempFile("vaulttest", "zip");
+        File tmpFile = Files.createTempFile("vaulttest", "zip").toFile();
         try (VaultPackage pkg = sourceOakRepository.packMgr.assemble(sourceOakRepository.admin, opts, tmpFile)) {
             Archive archive = pkg.getArchive();
 
@@ -142,7 +143,7 @@ public class NamespaceImportIT extends IntegrationTestBase {
         inf.setProperties(props);
         opts.setMetaInf(inf);
 
-        File tmpFile = File.createTempFile("vaulttest", "zip");
+        File tmpFile = Files.createTempFile("vaulttest", "zip").toFile();
         try (VaultPackage pkg = sourceOakRepository.packMgr.assemble(sourceOakRepository.admin, opts, tmpFile)) {
             Archive archive = pkg.getArchive();
 

--- a/vault-core/src/test/java/org/apache/jackrabbit/vault/packaging/integration/PackageTypesIT.java
+++ b/vault-core/src/test/java/org/apache/jackrabbit/vault/packaging/integration/PackageTypesIT.java
@@ -19,6 +19,7 @@ package org.apache.jackrabbit.vault.packaging.integration;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.util.Properties;
 
 import javax.jcr.RepositoryException;
@@ -77,7 +78,7 @@ public class PackageTypesIT extends IntegrationTestBase {
 
         options.setMetaInf(meta);
 
-        File tmpFile = File.createTempFile("vaulttest", "zip");
+        File tmpFile = Files.createTempFile("vaulttest", "zip").toFile();
         try (VaultPackage pkg = packMgr.assemble(admin, options, tmpFile)) {
             PackageType result = pkg.getProperties().getPackageType();
             assertEquals("Package type", expected, result);

--- a/vault-core/src/test/java/org/apache/jackrabbit/vault/packaging/integration/SerializationIT.java
+++ b/vault-core/src/test/java/org/apache/jackrabbit/vault/packaging/integration/SerializationIT.java
@@ -22,6 +22,7 @@ import static org.junit.Assert.assertNotNull;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.util.Properties;
 
 import javax.jcr.Node;
@@ -59,7 +60,7 @@ public class SerializationIT extends IntegrationTestBase {
         inf.setProperties(props);
 
         opts.setMetaInf(inf);
-        File tmpFile = File.createTempFile("vaulttest", "zip");
+        File tmpFile = Files.createTempFile("vaulttest", "zip").toFile();
         VaultPackage pkg = packMgr.assemble(admin, opts, tmpFile);
 
         // check if entries are present

--- a/vault-core/src/test/java/org/apache/jackrabbit/vault/packaging/integration/SpecialDoublePropertiesIT.java
+++ b/vault-core/src/test/java/org/apache/jackrabbit/vault/packaging/integration/SpecialDoublePropertiesIT.java
@@ -21,6 +21,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.Reader;
+import java.nio.file.Files;
 import java.util.Properties;
 
 import javax.jcr.Node;
@@ -64,7 +65,7 @@ public class SpecialDoublePropertiesIT extends IntegrationTestBase {
         inf.setProperties(props);
 
         opts.setMetaInf(inf);
-        File tmpFile = File.createTempFile("vaulttest", ".zip");
+        File tmpFile = Files.createTempFile("vaulttest", ".zip").toFile();
         VaultPackage pkg = packMgr.assemble(admin, opts, tmpFile);
 
         Archive.Entry e = pkg.getArchive().getEntry("jcr_root/tmp/.content.xml");

--- a/vault-core/src/test/java/org/apache/jackrabbit/vault/packaging/integration/UserContentPackageIT.java
+++ b/vault-core/src/test/java/org/apache/jackrabbit/vault/packaging/integration/UserContentPackageIT.java
@@ -19,6 +19,7 @@ package org.apache.jackrabbit.vault.packaging.integration;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.util.Properties;
 
 import javax.jcr.Node;
@@ -507,7 +508,7 @@ public class UserContentPackageIT extends IntegrationTestBase {
 
         opts.setMetaInf(inf);
 
-        File tmpFile = File.createTempFile("vaulttest", ".zip");
+        File tmpFile = Files.createTempFile("vaulttest", ".zip").toFile();
         VaultPackage pkg = packMgr.assemble(admin, opts, tmpFile);
 
         pkg.close();

--- a/vault-core/src/test/java/org/apache/jackrabbit/vault/packaging/registry/impl/CompositePackageRegistryTest.java
+++ b/vault-core/src/test/java/org/apache/jackrabbit/vault/packaging/registry/impl/CompositePackageRegistryTest.java
@@ -19,6 +19,7 @@ package org.apache.jackrabbit.vault.packaging.registry.impl;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.Files;
 import java.util.Arrays;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -78,7 +79,7 @@ public class CompositePackageRegistryTest {
                 new MockPackageRegistry(PACKAGE1),
                 new MockPackageRegistry(MockPackageRegistry.NEW_PACKAGE_ID)
                 );
-        File file = File.createTempFile("vlt", null);
+        File file = Files.createTempFile("vlt", null).toFile();
         try {
             registry.register(file, false);
         } finally {
@@ -92,7 +93,7 @@ public class CompositePackageRegistryTest {
                 new MockPackageRegistry(PACKAGE1),
                 new MockPackageRegistry(PACKAGE3)
                 );
-        File file = File.createTempFile("vlt", null);
+        File file = Files.createTempFile("vlt", null).toFile();
         try {
             registry.register(file, false);
         } finally {
@@ -119,7 +120,7 @@ public class CompositePackageRegistryTest {
                 new MockPackageRegistry(PACKAGE1),
                 new MockPackageRegistry(PACKAGE3)
                 );
-        File file = File.createTempFile("vlt", null);
+        File file = Files.createTempFile("vlt", null).toFile();
         try {
             registry.registerExternal(file, false);
         } finally {

--- a/vault-core/src/test/java/org/apache/jackrabbit/vault/packaging/registry/impl/FSRegisteredPackageTest.java
+++ b/vault-core/src/test/java/org/apache/jackrabbit/vault/packaging/registry/impl/FSRegisteredPackageTest.java
@@ -25,6 +25,7 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.Files;
 import java.util.Properties;
 
 import org.apache.commons.io.FileUtils;
@@ -43,7 +44,7 @@ public class FSRegisteredPackageTest {
     private static final PackageId DUMMY_ID = new PackageId("someGroup", "someName", "someVersion");
 
     private File getTempFile(String name) throws IOException {
-        File tmpFile = File.createTempFile("vaultpack", ".zip");
+        File tmpFile = Files.createTempFile("vaultpack", ".zip").toFile();
         try (InputStream in = getClass().getResourceAsStream(name);
             FileOutputStream out = FileUtils.openOutputStream(tmpFile)) {
             IOUtils.copy(in, out);

--- a/vault-vlt/src/main/java/org/apache/jackrabbit/vault/vlt/meta/xml/zip/UpdateableZipFile.java
+++ b/vault-vlt/src/main/java/org/apache/jackrabbit/vault/vlt/meta/xml/zip/UpdateableZipFile.java
@@ -23,6 +23,7 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.Files;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -155,7 +156,7 @@ public class UpdateableZipFile {
             return;
         }
         // create tmp file
-        File newZip = File.createTempFile(file.getName(), ".tmp", file.getParentFile());
+        File newZip = Files.createTempFile(file.getParentFile().toPath(), file.getName(), ".tmp").toFile();
         try (ZipOutputStream out = new ZipOutputStream(
                 new BufferedOutputStream(new FileOutputStream(newZip)))) {
             out.setLevel(Deflater.NO_COMPRESSION);

--- a/vault-vlt/src/main/java/org/apache/jackrabbit/vault/vlt/meta/xml/zip/ZipMetaFile.java
+++ b/vault-vlt/src/main/java/org/apache/jackrabbit/vault/vlt/meta/xml/zip/ZipMetaFile.java
@@ -25,6 +25,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
+import java.nio.file.Files;
 import java.util.zip.ZipEntry;
 
 import org.apache.commons.io.FileUtils;
@@ -111,7 +112,7 @@ public class ZipMetaFile implements MetaFile {
     public File openTempFile() throws IOException {
         if (tmpFile == null) {
             File parentDir = parent.getZip().getZipFile().getParentFile();
-            tmpFile = File.createTempFile(".vlt-", ".tmp", parentDir);
+            tmpFile = Files.createTempFile(parentDir.toPath(), ".vlt-", ".tmp").toFile();
             tmpFile.createNewFile();
             copyToSilent(tmpFile, true);
         }


### PR DESCRIPTION

# Security Vulnerability Fix

This pull request fixes a Temporary File Information Disclosure Vulnerability, which existed in this project.

## Preamble

The system temporary directory is shared between all users on most unix-like systems (not MacOS, or Windows). Thus, code interacting with the system temporary directory must be careful about file interactions in this directory, and must ensure that the correct file posix permissions are set.

This PR was generated because a call to `File.createTempFile(..)` was detected in this repository in a way that makes this project vulnerable to local information disclosure.
With the default uname configuration, `File.createTempFile(..)` creates a file with the permissions `-rw-r--r--`. This means that any other user on the system can read the contents of this file.

### Impact

Information in this file is visible to other local users, allowing a malicious actor co-resident on the same machine to view potentially sensitive files.

#### Other Examples

 - [CVE-2020-15250](https://github.com/advisories/GHSA-269g-pwp5-87pp) - junit-team/junit
 - [CVE-2021-21364](https://github.com/advisories/GHSA-hpv8-9rq5-hq7w) - swagger-api/swagger-codegen
 - [CVE-2022-24823](https://github.com/advisories/GHSA-5mcr-gq6c-3hq2) - netty/netty
 - [CVE-2022-24823](https://github.com/advisories/GHSA-269q-hmxg-m83q) - netty/netty

# The Fix

The fix has been to convert the logic above to use the following API that was introduced in Java 1.7.

```java
File tmpDir = Files.createTempFile("temp dir").toFile();
```

The API both creates the file securely, ie. with a random, non-conflicting name, with file permissions that only allow the currently executing user to read or write the contents of this file.
By default, `Files.createTempFile("temp dir")` will create a file with the permissions `-rw-------`, which only allows the user that created the file to view/write the file contents.

# :arrow_right: Vulnerability Disclosure :arrow_left:

:wave: Vulnerability disclosure is a super important part of the vulnerability handling process and should not be skipped! This may be completely new to you, and that's okay, I'm here to assist!

First question, do we need to perform vulnerability disclosure? It depends!

 1. Is the vulnerable code only in tests or example code? No disclosure required!
 2. Is the vulnerable code in code shipped to your end users? Vulnerability disclosure is probably required!

## Vulnerability Disclosure How-To

You have a few options options to perform vulnerability disclosure. However, I'd like to suggest the following 2 options:

 1. Request a CVE number from GitHub by creating a repository-level [GitHub Security Advisory](https://docs.github.com/en/code-security/repository-security-advisories/creating-a-repository-security-advisory). This has the advantage that, if you provide sufficient information, GitHub will automatically generate Dependabot alerts for your downstream consumers, resolving this vulnerability more quickly.
 2. Reach out to the team at Snyk to assist with CVE issuance. They can be reached at the [Snyk's Disclosure Email](mailto:report@snyk.io).

## Detecting this and Future Vulnerabilities

This vulnerability was automatically detected by GitHub's CodeQL using this [CodeQL Query](https://codeql.github.com/codeql-query-help/java/java-local-temp-file-or-directory-information-disclosure/).

You can automatically detect future vulnerabilities like this by enabling the free (for open-source) [GitHub Action](https://github.com/github/codeql-action).

I'm not an employee of GitHub, I'm simply an open-source security researcher.

## Source

This contribution was automatically generated with an [OpenRewrite](https://github.com/openrewrite/rewrite) [refactoring recipe](https://docs.openrewrite.org/), which was lovingly hand crafted to bring this security fix to your repository.

The source code that generated this PR can be found here:
[SecureTempFileCreation](https://github.com/openrewrite/rewrite-java-security/blob/main/src/main/java/org/openrewrite/java/security/SecureTempFileCreation.java)

## Opting-Out

If you'd like to opt-out of future automated security vulnerability fixes like this, please consider adding a file called
`.github/GH-ROBOTS.txt` to your repository with the line:

```
User-agent: JLLeitschuh/security-research
Disallow: *
```

This bot will respect the [ROBOTS.txt](https://moz.com/learn/seo/robotstxt) format for future contributions.

Alternatively, if this project is no longer actively maintained, consider [archiving](https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-archiving-repositories) the repository.

## CLA Requirements

_This section is only relevant if your project requires contributors to sign a Contributor License Agreement (CLA) for external contributions._

It is unlikely that I'll be able to directly sign CLAs. However, all contributed commits are already automatically signed-off.

> The meaning of a signoff depends on the project, but it typically certifies that committer has the rights to submit this work under the same license and agrees to a Developer Certificate of Origin
> (see [https://developercertificate.org/](https://developercertificate.org/) for more information).
>
> \- [Git Commit Signoff documentation](https://developercertificate.org/)

If signing your organization's CLA is a strict-requirement for merging this contribution, please feel free to close this PR.

## Sponsorship & Support

This contribution is sponsored by HUMAN Security Inc. and the new Dan Kaminsky Fellowship, a fellowship created to celebrate Dan's memory and legacy by funding open-source work that makes the world a better (and more secure) place.

This PR was generated by [Moderne](https://www.moderne.io/), a free-for-open source SaaS offering that uses format-preserving AST transformations to fix bugs, standardize code style, apply best practices, migrate library versions, and fix common security vulnerabilities at scale.

## Tracking

All PR's generated as part of this fix are tracked here: https://github.com/JLLeitschuh/security-research/issues/18
