### PR TITLE
JCRVLT-672 use mavens ComparableVersion for package Version compareTo

### DIFF
--- a/vault-core/src/main/java/org/apache/jackrabbit/vault/packaging/Version.java
+++ b/vault-core/src/main/java/org/apache/jackrabbit/vault/packaging/Version.java
@@ -166,7 +166,7 @@ public class Version implements Comparable<Version> {
      * @see "https://cwiki.apache.org/confluence/display/MAVENOLD/Versioning"
      * @see "https://semver.org/spec/v1.0.0.html"
      */
-    public int compareTo(@NotNull Version o) {
+    public int compareTo(Version o) {
         ComparableVersion thisVersion = new ComparableVersion(toString());
         ComparableVersion otherVersion = new ComparableVersion(o.toString());
         return thisVersion.compareTo(otherVersion);

--- a/vault-core/src/main/java/org/apache/jackrabbit/vault/packaging/Version.java
+++ b/vault-core/src/main/java/org/apache/jackrabbit/vault/packaging/Version.java
@@ -140,9 +140,8 @@ public class Version implements Comparable<Version> {
      * <a href="https://maven.apache.org/">Apache Maven</a>. A version usually consists  out of three numerical parts separated by dot -
      * major version, minor version and patch level, and can be followed by a dash and a qualifier like SNAPSHOT.
      * Version numbers can also consist of fewer or more parts (numerical, string, ....).
-     * If the comparison is not resolved by comparing the numbers, the algorith resorts to the qualifier - see
-     * <a href="https://cwiki.apache.org/confluence/display/MAVENOLD/Versioning">"Versioning" on Maven Wiki</a>
-     * for details.
+     * The comparison of the versions conforms to the
+     * <a href="https://maven.apache.org/pom.html#version-order-specification">Maven version order specification</a>.
      *
      * <pre>
      * Some examples:
@@ -163,8 +162,8 @@ public class Version implements Comparable<Version> {
      * @return  a negative integer, zero, or a positive integer as this version
      *		is less than, equal to, or greater than the specified version.
      *
-     * @see "https://cwiki.apache.org/confluence/display/MAVENOLD/Versioning"
-     * @see "https://semver.org/spec/v1.0.0.html"
+     * @see <a href="https://maven.apache.org/pom.html#version-order-specification">Maven version order specification</a>
+     * @see <a href="https://semver.org/spec/v1.0.0.html">Semantic Versioning 1.0.0</a>
      */
     public int compareTo(Version o) {
         ComparableVersion thisVersion = new ComparableVersion(toString());

--- a/vault-core/src/main/java/org/apache/jackrabbit/vault/packaging/Version.java
+++ b/vault-core/src/main/java/org/apache/jackrabbit/vault/packaging/Version.java
@@ -137,9 +137,9 @@ public class Version implements Comparable<Version> {
 
     /**
      * Compares this version to the given one. The comparison is compatible to the ordering used by
-     * <a href="https://maven.apache.org/">Apache Maven</a>. It version consists normally from 3 numbers -
+     * <a href="https://maven.apache.org/">Apache Maven</a>. A version usually consists  out of three numerical parts separated by dot -
      * major version, minor version and patch level, and can be followed by a dash and a qualifier like SNAPSHOT.
-     * Version numbers can also consist of fewer or more numbers.
+     * Version numbers can also consist of fewer or more parts (numerical, string, ....).
      * If the comparison is not resolved by comparing the numbers, the algorith resorts to the qualifier - see
      * <a href="https://cwiki.apache.org/confluence/display/MAVENOLD/Versioning">"Versioning" on Maven Wiki</a>
      * for details.

--- a/vault-core/src/test/java/org/apache/jackrabbit/vault/packaging/DependencyTest.java
+++ b/vault-core/src/test/java/org/apache/jackrabbit/vault/packaging/DependencyTest.java
@@ -104,7 +104,7 @@ public class DependencyTest extends TestCase {
 
     public void testMatches() {
         PackageId id = PackageId.fromString("apache/jackrabbit/product:jcr-content:5.5.0-SNAPSHOT.20111116");
-        Dependency d = Dependency.fromString("apache/jackrabbit/product:jcr-content:[5.5.0,)");
+        Dependency d = Dependency.fromString("apache/jackrabbit/product:jcr-content:[5.5.0-SNAPSHOT,)");
         assertTrue(d.matches(id));
     }
 
@@ -125,4 +125,6 @@ public class DependencyTest extends TestCase {
         String expected = "n1,g2:n2,g3:n3:1,g4:n4:[1,2],g3";
         assertEquals(expected, Dependency.toString(DependencyUtil.add(d, Dependency.fromString("g3"))));
     }
+
+
 }

--- a/vault-core/src/test/java/org/apache/jackrabbit/vault/packaging/VersionRangeTest.java
+++ b/vault-core/src/test/java/org/apache/jackrabbit/vault/packaging/VersionRangeTest.java
@@ -106,8 +106,8 @@ public class VersionRangeTest extends TestCase {
     }
 
     /**
-     * A snapshot precedes the released version, so 1.0-SNAPSHOT not contained in the range [1.0,2.0)
-     * - but the bound can be a snapshot.
+     * A snapshot precedes the released version, so 1.0-SNAPSHOT is not contained in the range [1.0,2.0)
+     * - but the boundary can be a snapshot.
      *
      * @see "https://github.com/apache/maven/blob/maven-3.8.6/maven-artifact/src/test/java/org/apache/maven/artifact/versioning/VersionRangeTest.java#L657"
      */

--- a/vault-core/src/test/java/org/apache/jackrabbit/vault/packaging/VersionRangeTest.java
+++ b/vault-core/src/test/java/org/apache/jackrabbit/vault/packaging/VersionRangeTest.java
@@ -109,7 +109,7 @@ public class VersionRangeTest extends TestCase {
      * A snapshot precedes the released version, so 1.0-SNAPSHOT is not contained in the range [1.0,2.0)
      * - but the boundary can be a snapshot.
      *
-     * @see "https://github.com/apache/maven/blob/maven-3.8.6/maven-artifact/src/test/java/org/apache/maven/artifact/versioning/VersionRangeTest.java#L657"
+     * @see <a href="https://github.com/apache/maven/blob/maven-3.8.6/maven-artifact/src/test/java/org/apache/maven/artifact/versioning/VersionRangeTest.java#L657">Maven VersionRangeTest.java</a>
      */
     public void testRangeSnapshots() {
         VersionRange vr = VersionRange.fromString("[1.0,2.0)");

--- a/vault-core/src/test/java/org/apache/jackrabbit/vault/packaging/VersionRangeTest.java
+++ b/vault-core/src/test/java/org/apache/jackrabbit/vault/packaging/VersionRangeTest.java
@@ -105,9 +105,18 @@ public class VersionRangeTest extends TestCase {
         assertFalse("[1.0,2.0] excludes empty version", vr.isInRange(Version.EMPTY));
     }
 
+    /**
+     * A snapshot precedes the released version, so 1.0-SNAPSHOT not contained in the range [1.0,2.0)
+     * - but the bound can be a snapshot.
+     *
+     * @see "https://github.com/apache/maven/blob/maven-3.8.6/maven-artifact/src/test/java/org/apache/maven/artifact/versioning/VersionRangeTest.java#L657"
+     */
     public void testRangeSnapshots() {
         VersionRange vr = VersionRange.fromString("[1.0,2.0)");
-        assertTrue("[1.0,2.0) includes 1.0-SNAPSHOT", vr.isInRange(v1s));
+        assertFalse("[1.0,2.0) excludes 1.0-SNAPSHOT", vr.isInRange(v1s));
+
+        vr = VersionRange.fromString("[1.0-SNAPSHOT,2.0)");
+        assertTrue("[1.0-SNAPSHOT,2.0) includes 1.0-SNAPSHOT", vr.isInRange(v1s));
     }
 
     public void testRangeInvalid() {

--- a/vault-core/src/test/java/org/apache/jackrabbit/vault/packaging/VersionTest.java
+++ b/vault-core/src/test/java/org/apache/jackrabbit/vault/packaging/VersionTest.java
@@ -17,7 +17,11 @@
 
 package org.apache.jackrabbit.vault.packaging;
 
+import org.hamcrest.CoreMatchers;
+import org.hamcrest.MatcherAssert;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ErrorCollector;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
@@ -27,6 +31,9 @@ import static org.junit.Assert.fail;
  * {@code VersionTest}...
  */
 public class VersionTest  {
+
+    @Rule
+    public ErrorCollector errorCollector = new ErrorCollector();
 
     @Test
     public void testFromSegments() {
@@ -64,20 +71,23 @@ public class VersionTest  {
         compare("1.1", "1.0.0", 1);
         compare("1.11", "1.9", 1);
         compare("1.1-SNAPSHOT", "1.0.0", 1);
-        compare("2.0", "2.0-beta-8", -1);
-        compare("2.0", "2.0-SNAPSHOT", -1);
+        compare("2.0", "2.0.1", -1);
+        compare("2.0", "2.0-beta-8", 1);
+        compare("2.0", "2.0-SNAPSHOT", 1);
         compare("1.11", "1.9-SNAPSHOT", 1);
         compare("1.11-SNAPSHOT", "1.9-SNAPSHOT", 1);
         compare("1.11-SNAPSHOT", "1.9", 1);
-        compare("1.1", "1.1-SNAPSHOT", -1);
-        compare("1.1-SNAPSHOT", "1.1-R12345", 1);
+        compare("1.1", "1.1-SNAPSHOT", 1);
+        compare("1.1-SNAPSHOT", "1.1-RC1", 1);
+        compare("1.1-SNAPSHOT", "1.1-R12345", -1);
+        compare("1.1.0-final", "1.1.0", 0);
         compare("2.1.492-NPR-12954-R012", "2.1.476", 1);
         compare("6.1.58", "6.1.58-FP3", -1);
         compare("6.1.58", "6.1.58.FP3", -1);
         compare("6.1.59", "6.1.58.FP3", 1);
         compare("6.1.58-FP3", "6.1.58-FP2", 1);
-        compare("6.1.58-FP3", "6.1.58.FP3", 0);
-        compare("6.1.58-FP3", "6.1.58.FP4", -1);
+        compare("6.1.58-FP3", "6.1.58.FP3", 1);
+        compare("6.1.58-FP3", "6.1.58.FP4", 1);
         compare("6.1.58.FP3", "6.1.58-FP4", -1);
         compare("6.1.58.FP3", "6.1.58.FP4", -1);
         compare("6.1.0", "6.1-FP3", -1);
@@ -88,16 +98,8 @@ public class VersionTest  {
         Version vv1 = Version.create(v1);
         Version vv2 = Version.create(v2);
         int ret = vv1.compareTo(vv2);
-        if (ret == comp) {
-            return;
-        }
-        if (ret < 0 && comp < 0) {
-            return;
-        }
-        if (ret > 0 && comp > 0) {
-            return;
-        }
-        fail(v1 + " compare to " + v2 + " must return " + comp);
+        errorCollector.checkThat(v1 + " compare to " + v2,
+                Math.signum(ret), CoreMatchers.is(Math.signum(comp)));
     }
 
 }


### PR DESCRIPTION
Compare https://issues.apache.org/jira/browse/JCRVLT-672 : the advantage is that this properly orders e.g. -SNAPSHOT versions of packages before: previously, 1.2.3 < 1.2.3-SNAPSHOT , but normally you'd create 1.2.3-SNAPSHOT and only later the actual release 1.2.3 . When Version.compareTo is used to check whether a package is "newer" (as e.g. Adobe AEM does), it could refuse installing release 1.2.3 after 1.2.3-SNAPSHOT is installed, which is wrong.

This changes the logic of Version.compareTo to use the maven logic  https://maven.apache.org/pom.html#Version_Order_Specification  .