### PR TITLE
JCRVLT-674 ignore dependency-check false positives

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -281,7 +281,7 @@ Bundle-Category: jackrabbit
                 <plugin>
                     <groupId>org.owasp</groupId>
                     <artifactId>dependency-check-maven</artifactId>
-                    <version>7.2.0</version>
+                    <version>7.4.1</version>
                     <executions>
                         <execution>
                             <goals>

--- a/suppressions.xml
+++ b/suppressions.xml
@@ -50,5 +50,11 @@
        <packageUrl regex="true">^pkg:maven/org\.apache\.sling/org\.apache\.sling\.jcr\.api@.*$</packageUrl>
        <cve>CVE-2022-32549</cve>
     </suppress>
-    
+    <suppress>
+       <notes><![CDATA[
+       file name: h2-2.1.212.jar, usage in FileVault not affected, see https://github.com/h2database/h2database/issues/3686
+       ]]></notes>
+       <packageUrl regex="true">^pkg:maven/com\.h2database/h2@.*$</packageUrl>
+       <cve>CVE-2022-45868</cve>
+    </suppress>
 </suppressions>

--- a/vault-core/pom.xml
+++ b/vault-core/pom.xml
@@ -194,7 +194,7 @@
         <dependency>
             <groupId>com.fasterxml.woodstox</groupId>
             <artifactId>woodstox-core</artifactId>
-            <version>6.1.1</version>
+            <version>6.4.0</version>
             <!-- embedded, therefore not transitively relevant -->
             <scope>provided</scope>
         </dependency>


### PR DESCRIPTION
Update embedded Woodstox however to newest 6.4.0
Update dependency-check to newest 7.4.1