### PR TITLE
JCRVLT-683 expect import of principal-based Authz to obey acHandling rules

### DIFF
--- a/vault-core/src/main/java/org/apache/jackrabbit/vault/fs/io/Importer.java
+++ b/vault-core/src/main/java/org/apache/jackrabbit/vault/fs/io/Importer.java
@@ -328,7 +328,7 @@ public class Importer {
         this.isStrict = opts.isStrict(isStrictByDefault);
         this.isStrictByDefault = isStrictByDefault;
         this.overwritePrimaryTypesOfFoldersByDefault = overwritePrimaryTypesOfFoldersByDefault;
-        if (!this.opts.hasIdConflictPolicyBeenSet()) {
+        if (!this.opts.hasIdConflictPolicyBeenSet() && defaultIdConflictPolicy != null) {
             this.opts.setIdConflictPolicy(defaultIdConflictPolicy);
         }
     }

--- a/vault-core/src/test/resources/test-packages/principalbased_nopolicy.zip/META-INF/MANIFEST.MF
+++ b/vault-core/src/test/resources/test-packages/principalbased_nopolicy.zip/META-INF/MANIFEST.MF
@@ -1,0 +1,5 @@
+Manifest-Version: 1.0
+Content-Package-Roots: /home/users/system/intermediate
+Content-Package-Type: content
+Content-Package-Id: my_packages:testsystemuser
+

--- a/vault-core/src/test/resources/test-packages/principalbased_nopolicy.zip/META-INF/vault/config.xml
+++ b/vault-core/src/test/resources/test-packages/principalbased_nopolicy.zip/META-INF/vault/config.xml
@@ -1,0 +1,93 @@
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  -->
+<vaultfs version="1.1">
+    <!--
+        Defines the content aggregation. The order of the defined aggregates
+        is important for finding the correct aggregator.
+    -->
+    <aggregates>
+        <!--
+            Defines an aggregate that handles nt:file and nt:resource nodes.
+        -->
+        <aggregate type="file" title="File Aggregate"/>
+
+        <!--
+            Defines an aggregate that handles file/folder like nodes. It matches
+            all nt:hierarchyNode nodes that have or define a jcr:content
+            child node and excludes child nodes that are nt:hierarchyNodes.
+        -->
+        <aggregate type="filefolder" title="File/Folder Aggregate"/>
+
+        <!--
+            Defines an aggregate that handles nt:nodeType nodes and serializes
+            them into .cnd notation.
+        -->
+        <aggregate type="nodetype" title="Node Type Aggregate" />
+
+        <!--
+            Defines an aggregate that defines full coverage for certain node
+            types that cannot be covered by the default aggregator.
+        -->
+        <aggregate type="full" title="Full Coverage Aggregate">
+            <matches>
+                <include nodeType="rep:AccessControl" respectSupertype="true" />
+                <include nodeType="rep:Policy" respectSupertype="true" />
+                <include nodeType="cq:Widget" respectSupertype="true" />
+                <include nodeType="cq:EditConfig" respectSupertype="true" />
+                <include nodeType="cq:WorkflowModel" respectSupertype="true" />
+                <include nodeType="vlt:FullCoverage" respectSupertype="true" />
+                <include nodeType="mix:language" respectSupertype="true" />
+                <include nodeType="sling:OsgiConfig" respectSupertype="true" />
+            </matches>
+        </aggregate>
+
+        <!--
+            Defines an aggregate that handles nt:folder like nodes.
+        -->
+        <aggregate type="generic" title="Folder Aggregate">
+            <matches>
+                <include nodeType="nt:folder" respectSupertype="true" />
+            </matches>
+            <contains>
+                <exclude isNode="true" />
+            </contains>
+        </aggregate>
+
+        <!--
+            Defines the default aggregate
+        -->
+        <aggregate type="generic" title="Default Aggregator" isDefault="true">
+            <matches>
+                <!-- all -->
+            </matches>
+            <contains>
+                <exclude nodeType="nt:hierarchyNode" respectSupertype="true" />
+            </contains>
+        </aggregate>
+
+    </aggregates>
+
+    <!--
+      defines the input handlers
+    -->
+    <handlers>
+        <handler type="folder"/>
+        <handler type="file"/>
+        <handler type="nodetype"/>
+        <handler type="generic"/>
+    </handlers>
+</vaultfs>

--- a/vault-core/src/test/resources/test-packages/principalbased_nopolicy.zip/META-INF/vault/definition/.content.xml
+++ b/vault-core/src/test/resources/test-packages/principalbased_nopolicy.zip/META-INF/vault/definition/.content.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:vlt="http://www.day.com/jcr/vault/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0"
+    jcr:created="{Date}2019-07-23T10:20:20.089+02:00"
+    jcr:createdBy="admin"
+    jcr:description=""
+    jcr:lastModified="{Date}2019-07-23T10:20:20.089+02:00"
+    jcr:lastModifiedBy="admin"
+    jcr:primaryType="vlt:PackageDefinition"
+    buildCount="1"
+    builtWith=""
+    fixedBugs=""
+    group="integrationtesting"
+    lastUnwrapped="{Date}2019-07-23T10:20:20.089+02:00"
+    lastUnwrappedBy="admin"
+    lastWrapped="{Date}2019-07-23T10:20:20.089+02:00"
+    lastWrappedBy="admin"
+    name="principalbased_overwrite"
+    acHandling="OVERWRITE"
+    providerLink=""
+    providerName=""
+    providerUrl=""
+    testedWith=""
+    version="">
+    <filter jcr:primaryType="nt:unstructured">
+        <f0
+            jcr:primaryType="nt:unstructured"
+            mode="replace"
+            root="/home/users/system/intermediate"
+            rules="[]"/>
+    </filter>
+    <screenshots jcr:primaryType="nt:unstructured"/>
+</jcr:root>

--- a/vault-core/src/test/resources/test-packages/principalbased_nopolicy.zip/META-INF/vault/filter.xml
+++ b/vault-core/src/test/resources/test-packages/principalbased_nopolicy.zip/META-INF/vault/filter.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<workspaceFilter version="1.0">
+    <filter root="/home/users/system/intermediate" mode="update"/>
+</workspaceFilter>

--- a/vault-core/src/test/resources/test-packages/principalbased_nopolicy.zip/META-INF/vault/nodetypes.cnd
+++ b/vault-core/src/test/resources/test-packages/principalbased_nopolicy.zip/META-INF/vault/nodetypes.cnd
@@ -1,0 +1,10 @@
+<'rep'='internal'>
+
+[rep:Password]
+  - * (undefined) protected
+  - * (undefined) protected multiple
+
+[rep:RepoAccessControllable]
+  mixin
+  + rep:repoPolicy (rep:Policy) protected ignore
+

--- a/vault-core/src/test/resources/test-packages/principalbased_nopolicy.zip/META-INF/vault/properties.xml
+++ b/vault-core/src/test/resources/test-packages/principalbased_nopolicy.zip/META-INF/vault/properties.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<!DOCTYPE properties SYSTEM "http://java.sun.com/dtd/properties.dtd">
+<properties>
+<comment>FileVault Package Properties</comment>
+<entry key="createdBy">admin</entry>
+<entry key="name">principalbased_overwrite</entry>
+<entry key="lastModified">2019-07-23T10:20:20.089Z</entry>
+<entry key="lastModifiedBy">admin</entry>
+<entry key="created">2019-07-23T10:20:20.170+02:00</entry>
+<entry key="buildCount">1</entry>
+<entry key="version">2</entry>
+<entry key="packageType">content</entry>
+<entry key="dependencies">depgroup:dep1:1,depgroup:dep2:2</entry>
+<entry key="packageFormatVersion">2</entry>
+<entry key="description"/>
+<entry key="lastWrapped">2019-07-23T10:20:20.089+02:00</entry>
+<entry key="group">integrationtesting</entry>
+<entry key="lastWrappedBy">admin</entry>
+<entry key="acHandling">OVERWRITE</entry>
+<entry key="requiresRoot">true</entry>
+<entry key="foo">bar</entry>
+</properties>

--- a/vault-core/src/test/resources/test-packages/principalbased_nopolicy.zip/jcr_root/.content.xml
+++ b/vault-core/src/test/resources/test-packages/principalbased_nopolicy.zip/jcr_root/.content.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:rep="internal"
+    jcr:mixinTypes="[rep:AccessControllable,rep:RepoAccessControllable]"
+    jcr:primaryType="rep:root"
+    sling:resourceType="sling:redirect"
+    sling:target="/index.html"/>

--- a/vault-core/src/test/resources/test-packages/principalbased_nopolicy.zip/jcr_root/home/.content.xml
+++ b/vault-core/src/test/resources/test-packages/principalbased_nopolicy.zip/jcr_root/home/.content.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:rep="internal"
+    jcr:mixinTypes="[rep:AccessControllable]"
+    jcr:primaryType="rep:AuthorizableFolder"/>

--- a/vault-core/src/test/resources/test-packages/principalbased_nopolicy.zip/jcr_root/home/users/.content.xml
+++ b/vault-core/src/test/resources/test-packages/principalbased_nopolicy.zip/jcr_root/home/users/.content.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:rep="internal"
+    jcr:mixinTypes="[rep:AccessControllable]"
+    jcr:primaryType="rep:AuthorizableFolder"/>

--- a/vault-core/src/test/resources/test-packages/principalbased_nopolicy.zip/jcr_root/home/users/system/.content.xml
+++ b/vault-core/src/test/resources/test-packages/principalbased_nopolicy.zip/jcr_root/home/users/system/.content.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:rep="internal"
+    jcr:mixinTypes="[rep:AccessControllable]"
+    jcr:primaryType="rep:AuthorizableFolder"/>

--- a/vault-core/src/test/resources/test-packages/principalbased_nopolicy.zip/jcr_root/home/users/system/intermediate/.content.xml
+++ b/vault-core/src/test/resources/test-packages/principalbased_nopolicy.zip/jcr_root/home/users/system/intermediate/.content.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:rep="internal"
+    jcr:primaryType="rep:AuthorizableFolder"/>

--- a/vault-core/src/test/resources/test-packages/principalbased_nopolicy.zip/jcr_root/home/users/system/intermediate/tBUjdNwIM-i9bTqCYP5D/.content.xml
+++ b/vault-core/src/test/resources/test-packages/principalbased_nopolicy.zip/jcr_root/home/users/system/intermediate/tBUjdNwIM-i9bTqCYP5D/.content.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:rep="internal"
+    jcr:primaryType="rep:SystemUser"
+    jcr:mixinTypes="[rep:PrincipalBasedMixin]"
+    jcr:uuid="22a2d7fa-b8c4-3523-be63-1b5789e5694f"
+    rep:authorizableId="testSystemUser"
+    rep:principalName="testSystemUser"/>


### PR DESCRIPTION
The current state of PrincipalBasedIT actually asserts the unexpected behavior described in JCRVLT-683. I've changed those assertions to reflect what I expect the behavior to be, and I've added additional tests around each import/acHandling mode combination for scenarios where a new user is being imported, and where the package does not contain a principalPolicy for the principal being imported.