### PR TITLE
JCRVLT-703 always use original node context when reporting violations in

### DIFF
--- a/vault-validation/src/main/java/org/apache/jackrabbit/vault/validation/spi/impl/nodetype/JcrNodeTypeMetaDataImpl.java
+++ b/vault-validation/src/main/java/org/apache/jackrabbit/vault/validation/spi/impl/nodetype/JcrNodeTypeMetaDataImpl.java
@@ -62,6 +62,7 @@ import org.apache.jackrabbit.util.Text;
 import org.apache.jackrabbit.vault.validation.spi.NodeContext;
 import org.apache.jackrabbit.vault.validation.spi.ValidationMessage;
 import org.apache.jackrabbit.vault.validation.spi.ValidationMessageSeverity;
+import org.apache.jackrabbit.vault.validation.spi.util.NodeContextImpl;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -648,25 +649,8 @@ public class JcrNodeTypeMetaDataImpl implements JcrNodeTypeMetaData {
 
     public static @NotNull JcrNodeTypeMetaDataImpl createRoot(boolean isIncremental, @NotNull EffectiveNodeTypeProvider effectiveNodeTypeProvider)
             throws ConstraintViolationException, NoSuchNodeTypeException {
-        return new JcrNodeTypeMetaDataImpl(isIncremental, new NodeContext() {
-
-            @Override
-            public @NotNull String getNodePath() {
-                return "";
-            }
-
-            @Override
-            @NotNull
-            public java.nio.file.@NotNull Path getFilePath() {
-                return Paths.get("");
-            }
-
-            @Override
-            public java.nio.file.@NotNull Path getBasePath() {
-                return Paths.get("");
-            }
-            
-        }, NameConstants.ROOT, NameConstants.REP_ROOT, effectiveNodeTypeProvider.getEffectiveNodeType(
+        return new JcrNodeTypeMetaDataImpl(isIncremental, new NodeContextImpl("", Paths.get(""), Paths.get("")),
+            NameConstants.ROOT, NameConstants.REP_ROOT, effectiveNodeTypeProvider.getEffectiveNodeType(
                 new Name[] {
                         NameConstants.REP_ROOT,
                         NameConstants.REP_ACCESS_CONTROLLABLE,

--- a/vault-validation/src/main/java/org/apache/jackrabbit/vault/validation/spi/impl/nodetype/JcrNodeTypeMetaDataImpl.java
+++ b/vault-validation/src/main/java/org/apache/jackrabbit/vault/validation/spi/impl/nodetype/JcrNodeTypeMetaDataImpl.java
@@ -334,7 +334,7 @@ public class JcrNodeTypeMetaDataImpl implements JcrNodeTypeMetaData {
             // in incremental validations ignore missing mandatory properties and child nodes (as they might not be visible to the validator)
             if (!isIncremental) {
                 messages.add(new ValidationMessage(ValidationMessageSeverity.DEBUG,
-                        "Validate children and mandatory properties of " + getQualifiedPath(namePathResolver)));
+                        "Validate children and mandatory properties of " + getQualifiedPath(namePathResolver), context));
                 messages.addAll(validateChildNodes(namePathResolver, nodeTypeDefinitionProvider, itemDefinitionProvider, severity, severityForDefaultNodeTypeViolations, filter));
                 messages.addAll(validateMandatoryProperties(namePathResolver, severity, severityForDefaultNodeTypeViolations));
             }
@@ -342,11 +342,11 @@ public class JcrNodeTypeMetaDataImpl implements JcrNodeTypeMetaData {
             childNodesByName.clear();
             isValidationDone = true;
             messages.add(new ValidationMessage(ValidationMessageSeverity.DEBUG,
-                    "Remove node information of children of " + getQualifiedPath(namePathResolver)));
+                    "Remove node information of children of " + getQualifiedPath(namePathResolver), context));
             return messages;
         } else {
             return Collections.singletonList(new ValidationMessage(ValidationMessageSeverity.DEBUG,
-                    "Already finalized validation of " + getQualifiedPath(namePathResolver)));
+                    "Already finalized validation of " + getQualifiedPath(namePathResolver), context));
         }
     }
 
@@ -397,7 +397,7 @@ public class JcrNodeTypeMetaDataImpl implements JcrNodeTypeMetaData {
                         messages.add(new ValidationMessage(isImplicit ? severityForDefaultNodeTypeViolations : severity,
                                 String.format(MESSAGE_MANDATORY_CHILD_NODE_MISSING,
                                 getNodeDefinitionLabel(namePathResolver, mandatoryNodeType),
-                                getEffectiveNodeTypeLabel(namePathResolver, effectiveNodeType))));
+                                getEffectiveNodeTypeLabel(namePathResolver, effectiveNodeType)), context));
                     } else {
                         // if mandatory child nodes are missing outside filter rules, this is not an issue
                         messages.add(new ValidationMessage(ValidationMessageSeverity.DEBUG, String.format(MESSAGE_MANDATORY_UNCONTAINED_CHILD_NODE_MISSING,

--- a/vault-validation/src/test/java/org/apache/jackrabbit/vault/validation/spi/impl/nodetype/JcrNodeTypeMetaDataImplTest.java
+++ b/vault-validation/src/test/java/org/apache/jackrabbit/vault/validation/spi/impl/nodetype/JcrNodeTypeMetaDataImplTest.java
@@ -142,8 +142,8 @@ public class JcrNodeTypeMetaDataImplTest {
                 ntManagerProvider.getItemDefinitionProvider(), ValidationMessageSeverity.ERROR, ValidationMessageSeverity.ERROR, filter);
         ValidationExecutorTest.assertViolation(messages,
                 new ValidationMessage(ValidationMessageSeverity.ERROR,
-                        String.format(JcrNodeTypeMetaDataImpl.MESSAGE_MANDATORY_CHILD_NODE_MISSING, "jcr:content [nt:base]", "types [nt:file]",
-                        nodeContext)));
+                        String.format(JcrNodeTypeMetaDataImpl.MESSAGE_MANDATORY_CHILD_NODE_MISSING, "jcr:content [nt:base]", "types [nt:file]"),
+                        nodeContext));
     }
     
     @Test
@@ -256,9 +256,10 @@ public class JcrNodeTypeMetaDataImplTest {
                 ValidationMessageSeverity.ERROR, ValidationMessageSeverity.ERROR, filter);
         MatcherAssert.assertThat(messages, AnyValidationViolationMessageMatcher.noValidationViolationMessageInCollection());
 
+        NodeContext nodeContext = createSimpleNodeContext("name2");
         node = root.addChildNode(ntManagerProvider.getNamePathResolver(),
                 ntManagerProvider.getEffectiveNodeTypeProvider(), ntManagerProvider.getNodeTypeDefinitionProvider(),
-                ntManagerProvider.getItemDefinitionProvider(), createSimpleNodeContext("name2"),
+                ntManagerProvider.getItemDefinitionProvider(), nodeContext,
                 "my:nodeType1");
         
         // mandatory child node missing inside filter
@@ -267,7 +268,7 @@ public class JcrNodeTypeMetaDataImplTest {
                 ntManagerProvider.getItemDefinitionProvider(),ValidationMessageSeverity.ERROR, ValidationMessageSeverity.ERROR, filter);
         ValidationExecutorTest.assertViolation(messages, new ValidationMessage(ValidationMessageSeverity.ERROR,
                 String.format(JcrNodeTypeMetaDataImpl.MESSAGE_MANDATORY_CHILD_NODE_MISSING, "my:namedChild1 [my:nodeType1]", "types [my:nodeType1]",
-                        "/name2")));
+                        "/name2"), nodeContext));
 
         // calling a second time will not lead to anything
         messages = node.finalizeValidation(ntManagerProvider.getNamePathResolver(), ntManagerProvider.getNodeTypeDefinitionProvider(),
@@ -295,7 +296,7 @@ public class JcrNodeTypeMetaDataImplTest {
                 ntManagerProvider.getItemDefinitionProvider(),ValidationMessageSeverity.ERROR, ValidationMessageSeverity.ERROR,  "property", false,
                 ValueFactoryImpl.getInstance().createValue("foo")), AnyValidationViolationMessageMatcher.noValidationViolationMessageInCollection());
         
-        NodeContext nodeContext = createSimpleNodeContext("nodeForMandatoryProperties");
+        nodeContext = createSimpleNodeContext("nodeForMandatoryProperties");
         node = root.addChildNode(ntManagerProvider.getNamePathResolver(),
                 ntManagerProvider.getEffectiveNodeTypeProvider(), ntManagerProvider.getNodeTypeDefinitionProvider(),
                 ntManagerProvider.getItemDefinitionProvider(), nodeContext, "my:nodeType2");

--- a/vault-validation/src/test/java/org/apache/jackrabbit/vault/validation/spi/impl/nodetype/NodeTypeValidatorTest.java
+++ b/vault-validation/src/test/java/org/apache/jackrabbit/vault/validation/spi/impl/nodetype/NodeTypeValidatorTest.java
@@ -182,7 +182,7 @@ public class NodeTypeValidatorTest {
         ValidationExecutorTest.assertViolation(validator.done(),
                 new ValidationMessage(ValidationMessageSeverity.ERROR,
                         String.format(JcrNodeTypeMetaDataImpl.MESSAGE_MANDATORY_CHILD_NODE_MISSING,
-                                "jcr:content [nt:base]", "types [nt:file]", "/apps/test/node4")));
+                                "jcr:content [nt:base]", "types [nt:file]", "/apps/test/node4"), nodeContext));
         MatcherAssert.assertThat(validator.done(), AnyValidationViolationMessageMatcher.noValidationViolationMessageInCollection());
     }
 


### PR DESCRIPTION
finalizeValidationForSiblings/Subtree