### PR TITLE
JCRVLT-718 fix DocViewParserHandler.endDocViewNode's nodePath argument

### DIFF
--- a/vault-core/src/main/java/org/apache/jackrabbit/vault/fs/impl/io/DocViewSAXHandler.java
+++ b/vault-core/src/main/java/org/apache/jackrabbit/vault/fs/impl/io/DocViewSAXHandler.java
@@ -356,8 +356,8 @@ public class DocViewSAXHandler extends RejectingEntityDefaultHandler implements 
     public void endElement(String uri, String localName, String qName) throws SAXException {
         log.trace("<- element {}", qName);
         try {
-            currentPath = Text.getRelativeParent(currentPath, 1);
             handler.endDocViewNode(currentPath, nodeStack.pop(), Optional.ofNullable(nodeStack.peek()), locator.getLineNumber(), locator.getColumnNumber());
+            currentPath = Text.getRelativeParent(currentPath, 1);
         } catch (RepositoryException|IOException e) {
             throw new SAXException(e);
         }


### PR DESCRIPTION
Must point to currently ended node not to its parent