### PR TITLE
JCRVLT-721 check for rep:AuthorizableFolder nodetype before principal policy search

### DIFF
--- a/vault-core-it/vault-core-integration-tests/src/main/java/org/apache/jackrabbit/vault/fs/spi/impl/jcr20/JackrabbitACLManagementIT.java
+++ b/vault-core-it/vault-core-integration-tests/src/main/java/org/apache/jackrabbit/vault/fs/spi/impl/jcr20/JackrabbitACLManagementIT.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jackrabbit.vault.fs.spi.impl.jcr20;
+
+import org.apache.jackrabbit.vault.packaging.integration.IntegrationTestBase;
+import org.junit.Test;
+
+import javax.jcr.GuestCredentials;
+import javax.jcr.Node;
+import javax.jcr.Session;
+import javax.jcr.security.AccessControlPolicy;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Testcase for {@link JackrabbitACLManagement}
+ */
+public class JackrabbitACLManagementIT extends IntegrationTestBase {
+
+    @Test
+    public void testReadOnlyPermissionsOverHome() throws Exception {
+        Session session = repository.login(new GuestCredentials());
+        final String userId = session.getUserID();
+        JackrabbitACLManagement service = new JackrabbitACLManagement();
+        JackrabbitUserManagement userManagement = new JackrabbitUserManagement();
+        final String userPath = userManagement.getAuthorizablePath(session, userId);
+        assertNodeExists(userPath);
+        final Node userNode = session.getNode(userPath);
+        final Map<String, List<? extends AccessControlPolicy>> policies = service.getPrincipalAcls(userNode);
+        assertNotNull(policies);
+        assertTrue(policies.isEmpty());
+    }
+}

--- a/vault-core/src/main/java/org/apache/jackrabbit/vault/fs/spi/impl/jcr20/JackrabbitACLManagement.java
+++ b/vault-core/src/main/java/org/apache/jackrabbit/vault/fs/spi/impl/jcr20/JackrabbitACLManagement.java
@@ -190,14 +190,14 @@ public class JackrabbitACLManagement implements ACLManagement {
         return node.isNodeType(NT_REP_AUTHORIZABLE_FOLDER);
     }
 
-    private boolean areAuthorizablesAllowedBelowPath(Node node) throws RepositoryException {
+    private boolean areAuthorizablesAllowed(Node node) throws RepositoryException {
         return isAuthorizableFolder(node) || isAuthorizable(node);
     }
 
     @Override
     public @NotNull Map<String, List<? extends AccessControlPolicy>> getPrincipalAcls(Node node) throws RepositoryException {
         // first do a quick check if path may contain principal ACLs at all before triggering expensive traversal
-        if (!areAuthorizablesAllowedBelowPath(node)) {
+        if (!areAuthorizablesAllowed(node)) {
             return Collections.emptyMap();
         }
         JackrabbitSession jrSession = (JackrabbitSession)node.getSession();


### PR DESCRIPTION
Replaces the user/group creation test for determining the usersPath and groupsPath config values with a condition based only on the nodetype for the node being removed.