### PR TITLE
Improve the platform exporter

### DIFF
--- a/vault-core-it/vault-core-integration-tests/src/main/java/org/apache/jackrabbit/vault/sync/impl/VaultSyncServiceImplIT.java
+++ b/vault-core-it/vault-core-integration-tests/src/main/java/org/apache/jackrabbit/vault/sync/impl/VaultSyncServiceImplIT.java
@@ -61,7 +61,7 @@ public class VaultSyncServiceImplIT extends IntegrationTestBase {
             Path filterFile = syncRootDirectory1.resolve(".vlt-sync-filter.xml");
             assertTrue(Files.exists(filterFile));
             // check for file not yet being there in repo
-            assertNodeMissing("/testroot/testfile1.txt");
+            assertNodeMissing("/testroot/testfile.txt");
             // modify filter
             try (InputStream input = this.getClass().getResourceAsStream("filter.xml")) {
                 Files.copy(input, filterFile, StandardCopyOption.REPLACE_EXISTING);


### PR DESCRIPTION
Improve the platform exporter:
- Pruning
  keep track of the used directories and delete unused directories when pruning
- Tracking
  Track file creation with the correct action ('A', 'U').
  Track directory creation only - no tracking for existing directories

after #316 