### PR TITLE
JCRVLT-737 failing testcase

### DIFF
--- a/vault-core-it/vault-core-integration-tests/src/main/java/org/apache/jackrabbit/vault/packaging/integration/TestImportDuplicateUUIDs.java
+++ b/vault-core-it/vault-core-integration-tests/src/main/java/org/apache/jackrabbit/vault/packaging/integration/TestImportDuplicateUUIDs.java
@@ -1,0 +1,186 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jackrabbit.vault.packaging.integration;
+
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.StringReader;
+import java.util.Calendar;
+import java.util.Properties;
+
+import javax.jcr.Binary;
+import javax.jcr.Node;
+import javax.jcr.RepositoryException;
+import javax.jcr.UnsupportedRepositoryOperationException;
+import javax.jcr.ValueFactory;
+import javax.jcr.nodetype.NodeDefinitionTemplate;
+import javax.jcr.nodetype.NodeType;
+import javax.jcr.nodetype.NodeTypeManager;
+import javax.jcr.nodetype.NodeTypeTemplate;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.jackrabbit.commons.cnd.CndImporter;
+import org.apache.jackrabbit.commons.cnd.ParseException;
+import org.apache.jackrabbit.vault.fs.api.FilterSet;
+import org.apache.jackrabbit.vault.fs.api.IdConflictPolicy;
+import org.apache.jackrabbit.vault.fs.api.ImportMode;
+import org.apache.jackrabbit.vault.fs.api.PathFilter;
+import org.apache.jackrabbit.vault.fs.api.PathFilterSet;
+import org.apache.jackrabbit.vault.fs.config.ConfigurationException;
+import org.apache.jackrabbit.vault.fs.config.DefaultMetaInf;
+import org.apache.jackrabbit.vault.fs.config.DefaultWorkspaceFilter;
+import org.apache.jackrabbit.vault.fs.filter.DefaultPathFilter;
+import org.apache.jackrabbit.vault.fs.io.ImportOptions;
+import org.apache.jackrabbit.vault.fs.io.Importer;
+import org.apache.jackrabbit.vault.fs.io.ZipArchive;
+import org.apache.jackrabbit.vault.packaging.ExportOptions;
+import org.apache.jackrabbit.vault.packaging.VaultPackage;
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static javax.jcr.nodetype.NodeType.MIX_REFERENCEABLE;
+import static javax.jcr.nodetype.NodeType.NT_UNSTRUCTURED;
+import static org.apache.commons.lang3.RandomStringUtils.randomAlphanumeric;
+import static org.apache.jackrabbit.commons.JcrUtils.getOrCreateByPath;
+import static org.apache.jackrabbit.util.Text.getRelativeParent;
+import static org.apache.jackrabbit.vault.packaging.PackageProperties.NAME_GROUP;
+import static org.apache.jackrabbit.vault.packaging.PackageProperties.NAME_NAME;
+import static org.apache.jackrabbit.vault.util.PathUtil.append;
+
+public class TestImportDuplicateUUIDs extends IntegrationTestBase {
+
+    public static final String TEST_ROOT = "testroot";
+    
+    private static final Logger log = LoggerFactory.getLogger(TestImportDuplicateUUIDs.class);
+
+    private Node testRoot;
+    
+    private static final String NODE_TYPES = "[dam:Asset] > nt:hierarchyNode\n"
+    		+ "  primaryitem jcr:content\n"
+    		+ "  + jcr:content (dam:AssetContent) = dam:AssetContent\n"
+    		+ "  + * (nt:base) = nt:base version\n"
+    		+ "\n"
+    		+ "[dam:AssetContent] > nt:unstructured\n"
+    		+ "  + metadata (nt:unstructured)\n"
+    		+ "  + related (nt:unstructured)\n"
+    		+ "  + renditions (nt:folder)";
+    
+
+    @Before
+    public void before() throws RepositoryException, Exception {
+        testRoot = admin.getRootNode().addNode(TEST_ROOT);
+        admin.getWorkspace().getNamespaceRegistry().registerNamespace("dam", "http://www.day.com/day/dam");
+        
+        NodeTypeManager ntm = admin.getWorkspace().getNodeTypeManager();
+        
+        CndImporter.registerNodeTypes(new StringReader(NODE_TYPES), admin);
+        
+    }
+
+    
+    
+    
+    @Test
+    public void testInstallPackage() throws Exception {
+        String srcName = randomAlphanumeric(10) + ".png";
+        String srcPath = append(testRoot.getPath(), srcName);
+        String dstPath = srcPath + "-renamed";
+        
+        Node source = getOrCreateByPath(srcPath, NT_UNSTRUCTURED, "dam:Asset", admin, true);
+        Node child1 = source.addNode("jcr:content","dam:AssetContent");
+        child1.setProperty("someprop", "somevalue");
+        
+        addFileNode(source,"binary.png");
+
+        assertNodeExists(child1.getPath());
+        source.addMixin(MIX_REFERENCEABLE);
+        File pkgFile = exportContentPackage(srcPath);
+        admin.save();
+
+        admin.move(srcPath, dstPath);
+        assertNodeMissing(srcPath);
+        
+        installContentPackage(pkgFile, IdConflictPolicy.LEGACY);
+        
+        assertNodeExists(srcPath);
+        assertNodeExists(srcPath + "/child1");
+        assertProperty(child1.getPath() + "/someprop", "somevalue");
+    }
+
+    
+    private Node addFileNode (Node parent, String name) throws Exception {
+    	
+      ValueFactory valueFactory = parent.getSession().getValueFactory();           
+      Binary contentValue = valueFactory.createBinary(new ByteArrayInputStream("fake binary".getBytes()) );        
+      Node fileNode = parent.addNode(name, "nt:file");
+      Node resNode = fileNode.addNode("jcr:content", "nt:resource");
+      resNode.setProperty("jcr:mimeType", "image/png");
+      resNode.setProperty("jcr:data", contentValue);
+
+      Calendar lastModified = Calendar.getInstance();
+      lastModified.setTimeInMillis(lastModified.getTimeInMillis());
+      resNode.setProperty("jcr:lastModified", lastModified);
+      
+      return fileNode;
+    }
+    
+    private File exportContentPackage(String path) throws Exception {
+        ExportOptions opts = new ExportOptions();
+        DefaultMetaInf inf = new DefaultMetaInf();
+        DefaultWorkspaceFilter filter = new DefaultWorkspaceFilter();
+        
+        
+        PathFilterSet pfs = new PathFilterSet(path);
+        pfs.addInclude(new DefaultPathFilter(path + "/.*"));
+        filter.add(pfs);
+        
+        inf.setFilter(filter);
+        Properties props = new Properties();
+        props.setProperty(NAME_GROUP, "jackrabbit/test");
+        props.setProperty(NAME_NAME, "test-package");
+        inf.setProperties(props);
+        
+        opts.setMetaInf(inf);
+        File pkgFile = File.createTempFile("testImportMovedResource", ".zip");
+        try(VaultPackage pkg = packMgr.assemble(admin, opts, pkgFile)) {
+            return pkg.getFile();
+        }
+    }
+
+    private void installContentPackage(File pkgFile, IdConflictPolicy policy) throws RepositoryException, IOException, ConfigurationException {
+    	
+    	FileUtils.copyFile(pkgFile, new File("/Users/joerg/Day/customers/deloitte/2023-12-20/test", pkgFile.getName()));
+    	
+        try (ZipArchive archive = new ZipArchive(pkgFile);) {
+	        archive.open(true);
+	        ImportOptions opts = getDefaultOptions();
+	        opts.setIdConflictPolicy(policy);
+	        opts.setFilter(archive.getMetaInf().getFilter());
+	        opts.setImportMode(ImportMode.UPDATE_PROPERTIES);
+	        
+	        opts.setStrict(true);
+	        Importer importer = new Importer(opts);
+	        
+	        log.info("importing");
+	        importer.run(archive, admin.getRootNode());
+        }
+    }
+}

--- a/vault-core-it/vault-core-integration-tests/src/main/java/org/apache/jackrabbit/vault/packaging/integration/TestImportMovedResource.java
+++ b/vault-core-it/vault-core-integration-tests/src/main/java/org/apache/jackrabbit/vault/packaging/integration/TestImportMovedResource.java
@@ -1,0 +1,138 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jackrabbit.vault.packaging.integration;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Properties;
+
+import javax.jcr.Node;
+import javax.jcr.RepositoryException;
+
+import org.apache.jackrabbit.vault.fs.api.IdConflictPolicy;
+import org.apache.jackrabbit.vault.fs.api.PathFilterSet;
+import org.apache.jackrabbit.vault.fs.config.ConfigurationException;
+import org.apache.jackrabbit.vault.fs.config.DefaultMetaInf;
+import org.apache.jackrabbit.vault.fs.config.DefaultWorkspaceFilter;
+import org.apache.jackrabbit.vault.fs.io.ImportOptions;
+import org.apache.jackrabbit.vault.fs.io.Importer;
+import org.apache.jackrabbit.vault.fs.io.ZipArchive;
+import org.apache.jackrabbit.vault.packaging.ExportOptions;
+import org.apache.jackrabbit.vault.packaging.VaultPackage;
+import org.junit.Before;
+import org.junit.Test;
+
+import static javax.jcr.nodetype.NodeType.MIX_REFERENCEABLE;
+import static javax.jcr.nodetype.NodeType.NT_UNSTRUCTURED;
+import static org.apache.commons.lang3.RandomStringUtils.randomAlphanumeric;
+import static org.apache.jackrabbit.commons.JcrUtils.getOrCreateByPath;
+import static org.apache.jackrabbit.util.Text.getRelativeParent;
+import static org.apache.jackrabbit.vault.packaging.PackageProperties.NAME_GROUP;
+import static org.apache.jackrabbit.vault.packaging.PackageProperties.NAME_NAME;
+import static org.apache.jackrabbit.vault.util.PathUtil.append;
+
+public class TestImportMovedResource extends IntegrationTestBase {
+
+    public static final String TEST_ROOT = "testroot";
+
+    private Node testRoot;
+
+    @Before
+    public void before() throws RepositoryException {
+        testRoot = admin.getRootNode().addNode(TEST_ROOT);
+    }
+
+
+    @Test
+    public void testRename() throws Exception {
+        String srcName = randomAlphanumeric(10);
+        String srcPath = append(testRoot.getPath(), srcName);
+        String dstPath = srcPath + "-renamed";
+        test(srcPath, dstPath);
+    }
+
+    @Test
+    public void testMove() throws Exception {
+        String name = randomAlphanumeric(10);
+
+        String srcParent = append(testRoot.getPath(), randomAlphanumeric(10));
+        String srcPath = append(srcParent, name);
+
+        String dstParent = append(testRoot.getPath(), randomAlphanumeric(10));
+        String dstPath = append(dstParent, name);
+
+        test(srcPath, dstPath);
+    }
+
+    @Test
+    public void testMoveAndRename() throws Exception {
+        String srcName = randomAlphanumeric(10);
+
+        String srcParent = append(testRoot.getPath(), randomAlphanumeric(10));
+        String srcPath = append(srcParent, srcName);
+
+        String dstParent = append(testRoot.getPath(), randomAlphanumeric(10));
+        String dstPath = append(dstParent, srcName + "-renamed");
+
+        test(srcPath, dstPath);
+    }
+
+
+
+    private void test(String srcPath, String dstPath) throws RepositoryException, IOException, ConfigurationException {
+        getOrCreateByPath(getRelativeParent(srcPath, 1), NT_UNSTRUCTURED, NT_UNSTRUCTURED, admin, true);
+        getOrCreateByPath(getRelativeParent(dstPath, 1), NT_UNSTRUCTURED, NT_UNSTRUCTURED, admin, true);
+        Node original = getOrCreateByPath(srcPath, NT_UNSTRUCTURED, NT_UNSTRUCTURED, admin, true);
+        original.addMixin(MIX_REFERENCEABLE);
+        File pkgFile = export(srcPath);
+        admin.move(srcPath, dstPath);
+        assertNodeMissing(srcPath);
+        install(pkgFile);
+        assertNodeExists(srcPath);
+    }
+
+
+    private File export(String path) throws IOException, RepositoryException {
+        ExportOptions opts = new ExportOptions();
+        DefaultMetaInf inf = new DefaultMetaInf();
+        DefaultWorkspaceFilter filter = new DefaultWorkspaceFilter();
+        filter.add(new PathFilterSet(path));
+        inf.setFilter(filter);
+        Properties props = new Properties();
+        props.setProperty(NAME_GROUP, "jackrabbit/test");
+        props.setProperty(NAME_NAME, "test-package");
+        inf.setProperties(props);
+        opts.setMetaInf(inf);
+        File pkgFile = File.createTempFile("testImportMovedResource", ".zip");
+        try(VaultPackage pkg = packMgr.assemble(admin, opts, pkgFile)) {
+            return pkg.getFile();
+        }
+    }
+
+    private void install(File pkgFile) throws RepositoryException, IOException, ConfigurationException {
+        ZipArchive archive = new ZipArchive(pkgFile);
+        archive.open(true);
+        ImportOptions opts = getDefaultOptions();
+        opts.setIdConflictPolicy(IdConflictPolicy.LEGACY);
+        opts.setFilter(new DefaultWorkspaceFilter());
+        opts.setStrict(true);
+        Importer importer = new Importer(opts);
+        importer.run(archive, admin.getRootNode());
+
+    }
+}


### PR DESCRIPTION
I was able to create the testcase, which shows exactly the same exception trace for JCRVLT-737. I am quite sure that it can be simplified further. The breakthrough happened when I added the custom nodetypes.

I used this command to execute just this test:
```
$ cd vault-core-it
$ mvn clean install -Dit.test=TestImportDuplicateUUIDs
```

```
[INFO] Running org.apache.jackrabbit.vault.packaging.integration.TestImportDuplicateUUIDs
11:54:56.033 [main] INFO  o.a.j.v.p.i.IntegrationTestBase - repository created: Apache Jackrabbit Oak 1.52.0
11:54:56.623 [main] INFO  o.a.j.v.p.i.TestImportDuplicateUUIDs - importing
11:54:56.626 [main] INFO  o.a.j.v.p.i.IntegrationTestBase - Collecting import information...
11:54:56.628 [main] INFO  o.a.j.v.p.i.IntegrationTestBase - Installing node types...
11:54:56.635 [main] INFO  o.a.j.v.p.i.IntegrationTestBase - - jcr -> http://www.jcp.org/jcr/1.0
11:54:56.635 [main] INFO  o.a.j.v.p.i.IntegrationTestBase - - dam -> http://www.day.com/day/dam
11:54:56.635 [main] INFO  o.a.j.v.p.i.IntegrationTestBase - - nt -> http://www.jcp.org/jcr/nt/1.0
11:54:56.635 [main] INFO  o.a.j.v.p.i.IntegrationTestBase - - dam:Asset
11:54:56.636 [main] INFO  o.a.j.v.p.i.IntegrationTestBase - - dam:AssetContent
11:54:56.636 [main] INFO  o.a.j.v.p.i.IntegrationTestBase - Installing privileges...
11:54:56.636 [main] INFO  o.a.j.v.p.i.IntegrationTestBase - Importing content...
11:54:56.651 [main] INFO  o.a.j.v.p.i.IntegrationTestBase - - /
11:54:56.656 [main] INFO  o.a.j.v.p.i.IntegrationTestBase - - /testroot
11:54:56.662 [main] WARN  o.a.j.v.fs.impl.io.DocViewImporter - Node Collision: To-be imported node /testroot/tPS1iCUDVj.png uses a node identifier Optional[bf2330cb-a763-40a9-9d29-3c336d917bd0] which is already taken by /testroot/tPS1iCUDVj.png-renamed, trying to resolve conflict according to policy LEGACY
11:54:56.662 [main] WARN  o.a.j.v.fs.impl.io.DocViewImporter - Existing conflicting node /testroot/tPS1iCUDVj.png-renamed has same parent as to-be imported one and is not contained in the filter, ignoring new node but continue with children below existing conflicting node
11:54:56.664 [main] INFO  o.a.j.v.p.i.IntegrationTestBase - - /testroot/tPS1iCUDVj.png-renamed
11:54:56.665 [main] ERROR o.a.jackrabbit.vault.fs.io.Importer - E /testroot/tPS1iCUDVj.png/binary.png (java.lang.IllegalStateException: Parent node not found.)
11:54:56.665 [main] INFO  o.a.j.v.p.i.IntegrationTestBase - E /testroot/tPS1iCUDVj.png/binary.png java.lang.IllegalStateException: Parent node not found.
11:54:56.665 [main] INFO  o.a.j.v.p.i.IntegrationTestBase - saving approx 1 nodes...
11:54:56.713 [main] INFO  o.a.j.v.p.i.IntegrationTestBase - Package imported (with errors, check logs!)
[ERROR] Tests run: 1, Failures: 0, Errors: 1, Skipped: 0, Time elapsed: 2.377 s <<< FAILURE! -- in org.apache.jackrabbit.vault.packaging.integration.TestImportDuplicateUUIDs
[ERROR] org.apache.jackrabbit.vault.packaging.integration.TestImportDuplicateUUIDs.testInstallPackage -- Time elapsed: 0.685 s <<< ERROR!
javax.jcr.RepositoryException: Some errors occurred while installing packages. Please check the logs for details. First exception is logged as cause.
	at org.apache.jackrabbit.vault.fs.io.Importer.run(Importer.java:579)
	at org.apache.jackrabbit.vault.fs.io.Importer.run(Importer.java:409)
	at org.apache.jackrabbit.vault.packaging.integration.TestImportDuplicateUUIDs.installContentPackage(TestImportDuplicateUUIDs.java:183)
	at org.apache.jackrabbit.vault.packaging.integration.TestImportDuplicateUUIDs.testInstallPackage(TestImportDuplicateUUIDs.java:121)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:59)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:56)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:26)
	at org.junit.internal.runners.statements.RunAfters.evaluate(RunAfters.java:27)
	at org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)
	at org.junit.runners.BlockJUnit4ClassRunner$1.evaluate(BlockJUnit4ClassRunner.java:100)
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:366)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:103)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:63)
	at org.junit.runners.ParentRunner$4.run(ParentRunner.java:331)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:79)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:329)
	at org.junit.runners.ParentRunner.access$100(ParentRunner.java:66)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:293)
	at org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:26)
	at org.junit.internal.runners.statements.RunAfters.evaluate(RunAfters.java:27)
	at org.junit.rules.ExternalResource$1.evaluate(ExternalResource.java:54)
	at org.junit.rules.RunRules.evaluate(RunRules.java:20)
	at org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:413)
	at org.apache.maven.surefire.junit4.JUnit4Provider.execute(JUnit4Provider.java:316)
	at org.apache.maven.surefire.junit4.JUnit4Provider.executeWithRerun(JUnit4Provider.java:240)
	at org.apache.maven.surefire.junit4.JUnit4Provider.executeTestSet(JUnit4Provider.java:214)
	at org.apache.maven.surefire.junit4.JUnit4Provider.invoke(JUnit4Provider.java:155)
	at org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:385)
	at org.apache.maven.surefire.booter.ForkedBooter.execute(ForkedBooter.java:162)
	at org.apache.maven.surefire.booter.ForkedBooter.run(ForkedBooter.java:507)
	at org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:495)
Caused by: org.apache.jackrabbit.vault.packaging.PackageException: Error creating/updating node /testroot/tPS1iCUDVj.png/binary.png
	at org.apache.jackrabbit.vault.fs.io.Importer.commit(Importer.java:1177)
	at org.apache.jackrabbit.vault.fs.io.Importer.commit(Importer.java:976)
	at org.apache.jackrabbit.vault.fs.io.Importer.commit(Importer.java:1018)
	at org.apache.jackrabbit.vault.fs.io.Importer.commit(Importer.java:1018)
	at org.apache.jackrabbit.vault.fs.io.Importer.commit(Importer.java:1018)
	at org.apache.jackrabbit.vault.fs.io.Importer.run(Importer.java:531)
	... 37 more
Caused by: java.lang.IllegalStateException: Parent node not found.
	at org.apache.jackrabbit.vault.fs.io.Importer.commit(Importer.java:1125)
	... 42 more
```