### PR TITLE
add missing filterSet to scrFilter

### DIFF
--- a/vault-rcp/src/main/java/org/apache/jackrabbit/vault/rcp/impl/RcpTaskImpl.java
+++ b/vault-rcp/src/main/java/org/apache/jackrabbit/vault/rcp/impl/RcpTaskImpl.java
@@ -173,6 +173,7 @@ public class RcpTaskImpl implements Runnable, RcpTask {
         for (String path : excludes) {
             filterSet.addExclude(new DefaultPathFilter(path));
         }
+        srcFilter.add(filterSet);
         return srcFilter;
     }
 


### PR DESCRIPTION
After a lot of searching I found the following error in the class "org.apache.jackrabbit.vault.rcp.impl.RcpTaskImpl":

private static WorkspaceFilter createFilterForExcludes(List<String> excludes) throws ConfigurationException {
    // could be done better
    DefaultWorkspaceFilter srcFilter = new DefaultWorkspaceFilter();
    PathFilterSet filterSet = new PathFilterSet("/");
    for (String path : excludes) {
        filterSet.addExclude(new DefaultPathFilter(path));
    }
    **srcFilter.add(filterSet);**
    return srcFilter;
}

The line marked bold was missing.
