### PR TITLE
JCRVLT-761 add method to generate qualified name from SPI name object

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -48,7 +48,7 @@ Apache Jackrabbit FileVault is a project of the Apache Software Foundation.
 
     <properties>
         <!-- CI-friendly version, https://maven.apache.org/maven-ci-friendly.html -->
-        <revision>3.7.3-SNAPSHOT</revision>
+        <revision>3.8.0-SNAPSHOT</revision>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <!-- for dependencies used for calculating OSGi import-package version ranges the minimally supported version should be used to be backwards compatible in OSGi containers -->
         <jackrabbit.min.version>2.20.8</jackrabbit.min.version>

--- a/vault-validation/src/main/java/org/apache/jackrabbit/vault/validation/spi/NodeContext.java
+++ b/vault-validation/src/main/java/org/apache/jackrabbit/vault/validation/spi/NodeContext.java
@@ -18,6 +18,7 @@ package org.apache.jackrabbit.vault.validation.spi;
 
 import java.nio.file.Path;
 
+import org.apache.jackrabbit.spi.Name;
 import org.jetbrains.annotations.NotNull;
 
 /**
@@ -64,5 +65,19 @@ public interface NodeContext {
      */
     default int getColumn() {
         return 0;
+    }
+
+    /**
+     * Returns a readable String from the given name object.
+     * The return value's format depends on the actual underlying context.
+     * 
+     * @param name the name object
+     * @return the <a href="https://s.apache.org/jcr-2.0-spec/3_Repository_Model.html#3.2.5.2%20Qualified%20Form">JCR qualified name</a> 
+     * or as fallback the <a href="https://s.apache.org/jcr-2.0-spec/3_Repository_Model.html#3.2.5.1%20Expanded%20Form">JCR expanded name</a>
+     * from the given name object
+     * @since 3.8.0
+     */
+    default @NotNull String getJcrName(@NotNull Name name) {
+        return name.toString();
     }
 }

--- a/vault-validation/src/main/java/org/apache/jackrabbit/vault/validation/spi/package-info.java
+++ b/vault-validation/src/main/java/org/apache/jackrabbit/vault/validation/spi/package-info.java
@@ -18,7 +18,7 @@
 /**
  * The FileVault validation framework SPI. Provides classes/interfaces to implement validators on FileVault packages.
  */
-@Version("1.8.0")
+@Version("1.9.0")
 package org.apache.jackrabbit.vault.validation.spi;
 
 import org.osgi.annotation.versioning.Version;

--- a/vault-validation/src/main/java/org/apache/jackrabbit/vault/validation/spi/util/NodeContextImpl.java
+++ b/vault-validation/src/main/java/org/apache/jackrabbit/vault/validation/spi/util/NodeContextImpl.java
@@ -18,7 +18,9 @@ package org.apache.jackrabbit.vault.validation.spi.util;
 
 import java.nio.file.Path;
 import java.util.Objects;
+import java.util.function.Function;
 
+import org.apache.jackrabbit.spi.Name;
 import org.apache.jackrabbit.vault.validation.spi.NodeContext;
 import org.jetbrains.annotations.NotNull;
 
@@ -28,18 +30,34 @@ public final class NodeContextImpl implements NodeContext {
     private final @NotNull Path basePath;
     private final int line;
     private final int column;
+    private final Function<Name, String> jcrNameResolver;
 
     public NodeContextImpl(@NotNull String nodePath, @NotNull Path filePath, @NotNull Path basePath) {
-        this(nodePath, filePath, basePath, 0, 0);
+        this(nodePath, filePath, basePath, 0, 0, Object::toString);
     }
 
+    /**
+     * 
+     * @param nodePath
+     * @param filePath
+     * @param basePath
+     * @param line
+     * @param column
+     * @deprecated Use {@link #NodeContextImpl(String, Path, Path, int, int, Function)} instead.
+     */
+    @Deprecated
     public NodeContextImpl(@NotNull String nodePath, @NotNull Path filePath, @NotNull Path basePath, int line, int column) {
+        this(nodePath, filePath, basePath, line, column, Object::toString );
+    }
+
+    public NodeContextImpl(@NotNull String nodePath, @NotNull Path filePath, @NotNull Path basePath, int line, int column, @NotNull Function<Name, String> jcrNameResolver) {
         super();
         this.nodePath = nodePath;
         this.filePath = filePath;
         this.basePath = basePath;
         this.line = line;
         this.column = column;
+        this.jcrNameResolver = jcrNameResolver;
     }
 
     @Override
@@ -65,6 +83,11 @@ public final class NodeContextImpl implements NodeContext {
     @Override
     public int getColumn() {
         return column;
+    }
+
+    @Override
+    public @NotNull String getJcrName(@NotNull Name name) {
+        return jcrNameResolver.apply(name);
     }
 
     @Override

--- a/vault-validation/src/main/java/org/apache/jackrabbit/vault/validation/spi/util/package-info.java
+++ b/vault-validation/src/main/java/org/apache/jackrabbit/vault/validation/spi/util/package-info.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-@Version("1.1.0")
+@Version("1.2.0")
 package org.apache.jackrabbit.vault.validation.spi.util;
 
 import org.osgi.annotation.versioning.Version;


### PR DESCRIPTION
This allows validator implementations to emit more user-friendly node/property names (leveraging qualified instead of expanded name).