### PR TITLE
JCRVLT-778 Always return singleton INFINITE for empty string in

### DIFF
--- a/vault-core/src/main/java/org/apache/jackrabbit/vault/packaging/VersionRange.java
+++ b/vault-core/src/main/java/org/apache/jackrabbit/vault/packaging/VersionRange.java
@@ -228,7 +228,7 @@ public class VersionRange {
             return new VersionRange(vLow, linc, vHigh, hinc);
         } else if (str.length() == 0) {
             // infinite range
-            return new VersionRange(null, false, null, false);
+            return VersionRange.INFINITE;
         } else {
             // simple range where given version is minimum
             return new VersionRange(Version.create(str), true, null, false);

--- a/vault-core/src/test/java/org/apache/jackrabbit/vault/packaging/VersionRangeTest.java
+++ b/vault-core/src/test/java/org/apache/jackrabbit/vault/packaging/VersionRangeTest.java
@@ -19,6 +19,7 @@ package org.apache.jackrabbit.vault.packaging;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -194,6 +195,12 @@ public class VersionRangeTest {
         assertEquals(null, vr.getLow());
         assertEquals(v2, vr.getHigh());
         assertEquals(true, vr.isHighInclusive());
+    }
+
+    @Test
+    public void testParseEmptyString() {
+        VersionRange vr = VersionRange.fromString("");
+        assertSame(VersionRange.INFINITE, vr); // always return same instance
     }
 
     @Test


### PR DESCRIPTION
fromString(String)

This reduces memory footprint