### PR TITLE
Restore broken Jacoco configuration

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -602,9 +602,33 @@ Bundle-Category: jackrabbit
                                     <append>true</append>
                                 </configuration>
                             </execution>
+                            <execution>
+                                <id>merge-unit-and-it</id>
+                                <phase>post-integration-test</phase>
+                                <goals>
+                                    <goal>merge</goal>
+                                </goals>
+                                <configuration>
+                                    <fileSets>
+                                        <fileSet>
+                                            <directory>${project.build.directory}</directory>
+                                            <includes>
+                                                <include>jacoco-unit.exec</include>
+                                                <include>jacoco-it.exec</include>
+                                            </includes>
+                                        </fileSet>
+                                    </fileSets>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>report-merged</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>report</goal>
+                                </goals>
+                            </execution>
                         </executions>
                     </plugin>
-                    
                 </plugins>
             </build>
         </profile>

--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
 
     <properties>
         <project.build.outputTimestamp>2024-08-01T07:16:26Z</project.build.outputTimestamp>
-        <!-- https://docs.sonarcloud.io/enriching/test-coverage/test-coverage-parameters/#javakotlinscalajvm -->
+        <!-- this project uses cross-module reports with one aggregate, https://docs.sonarsource.com/sonarcloud/enriching/test-coverage/java-test-coverage/#add-coverage-in-a-multi-module-maven-project -->
         <sonar.coverage.jacoco.xmlReportPaths>${project.basedir}/vault-coverage-aggregate/target/site/jacoco-aggregate/jacoco.xml</sonar.coverage.jacoco.xmlReportPaths>
     </properties>
 

--- a/vault-coverage-aggregate/pom.xml
+++ b/vault-coverage-aggregate/pom.xml
@@ -113,6 +113,10 @@
                                 <!-- shaded 3rd party classes -->
                                 <include>org/apache/jackrabbit/vault/**</include>
                             </includes>
+                            <!-- only consider merged data files (consisting of both IT and UT) -->
+                            <dataFileIncludes>
+                               <dataFileInclude>**/jacoco.exec</dataFileInclude> 
+                            </dataFileIncludes>
                         </configuration>
                     </execution>
                 </executions>


### PR DESCRIPTION
This regressed with
https://github.com/apache/jackrabbit-filevault/commit/43ac160511b7c0ec5938413057924863b5e40191 Aggregate reports should be orthogonal to regular in-module UTs/ITs though.