### PR TITLE
JCRVLT-783 Deploy site.xml with parent

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -326,6 +326,20 @@ Bundle-Category: jackrabbit
                     </execution>
                 </executions>
             </plugin>
+            <!-- deploy site.xml as being used in downstream dependencies -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-site-plugin</artifactId>
+                <inherited>false</inherited>
+                <executions>
+                    <execution>
+                        <id>attach-descriptor</id>
+                        <goals>
+                            <goal>attach-descriptor</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>flatten-maven-plugin</artifactId>


### PR DESCRIPTION
This is used downstream and no longer deployed automatically since ASF parent 32 (https://issues.apache.org/jira/browse/MPOM-480)