### PR TITLE
JCRVLT-792 Fix NPE during export CLI command

### DIFF
--- a/vault-cli/src/main/java/org/apache/jackrabbit/vault/cli/CmdExport.java
+++ b/vault-cli/src/main/java/org/apache/jackrabbit/vault/cli/CmdExport.java
@@ -75,6 +75,7 @@ public class CmdExport extends AbstractJcrFsCommand {
             if (verbose) {
                 exporter.setVerbose(new DefaultProgressListener());
             }
+            exporter.setNoMetaInf(true);
             exporter.export(vaultFile);
             VaultFsApp.log.info("Exporting done.");
         } finally {

--- a/vault-cli/src/main/java/org/apache/jackrabbit/vault/cli/CmdExportCli.java
+++ b/vault-cli/src/main/java/org/apache/jackrabbit/vault/cli/CmdExportCli.java
@@ -112,6 +112,7 @@ public class CmdExportCli extends AbstractVaultCommand {
             if (verbose) {
                 exporter.setVerbose(new DefaultProgressListener());
             }
+            exporter.setNoMetaInf(true);
             exporter.export(vaultFile);
             VaultFsApp.log.info("Exporting done.");
         } finally {


### PR DESCRIPTION
The export does not have meta data, therefore explicitly skip exporting it.