### PR TITLE
JCRVLT-805 :  Removed the redundant call npResolver.getJCRName(prop.getName()) in DocViewImporter.setUnprotectedProperties

### DIFF
--- a/vault-core/src/main/java/org/apache/jackrabbit/vault/fs/impl/io/DocViewImporter.java
+++ b/vault-core/src/main/java/org/apache/jackrabbit/vault/fs/impl/io/DocViewImporter.java
@@ -1277,7 +1277,7 @@ public class DocViewImporter implements DocViewParserHandler {
         // add properties
         for (DocViewProperty2 prop : ni.getProperties()) {
             String name = npResolver.getJCRName(prop.getName());
-            if (prop != null && !isPropertyProtected(effectiveNodeType, prop) && (overwriteExistingProperties || !node.hasProperty(name)) && wspFilter.includesProperty(node.getPath() + "/" + npResolver.getJCRName(prop.getName()))) {
+            if (prop != null && !isPropertyProtected(effectiveNodeType, prop) && (overwriteExistingProperties || !node.hasProperty(name)) && wspFilter.includesProperty(node.getPath() + "/" + name)) {
                 // check if property is allowed
                 try {
                     modified |= prop.apply(node);


### PR DESCRIPTION
In DocViewImporter.setUnprotectedProperties npResolver.getJCRName(prop.getName()) is executed twice in a row. Removed the redundant call