### PR TITLE
JCRVLT-790 Really upgrade embedded JR2 dependencies to 2.22.1

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -51,7 +51,7 @@ Apache Jackrabbit FileVault is a project of the Apache Software Foundation.
         <revision>4.0.0-SNAPSHOT</revision>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <!-- for dependencies used for calculating OSGi import-package version ranges the minimally supported version should be used to be backwards compatible in OSGi containers -->
-        <jackrabbit.min.version>2.20.8</jackrabbit.min.version>
+        <jackrabbit.min.version>2.20.17</jackrabbit.min.version>
         <!-- for embedded dependencies the newest version should be used -->
         <jackrabbit.max.version>2.22.1</jackrabbit.max.version>
         <!-- for dependencies used for calculating OSGi import-package version ranges the minimally supported version should be used to be backwards compatible in OSGi containers -->

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -53,11 +53,11 @@ Apache Jackrabbit FileVault is a project of the Apache Software Foundation.
         <!-- for dependencies used for calculating OSGi import-package version ranges the minimally supported version should be used to be backwards compatible in OSGi containers -->
         <jackrabbit.min.version>2.20.8</jackrabbit.min.version>
         <!-- for embedded dependencies the newest version should be used -->
-        <jackrabbit.max.version>2.20.16</jackrabbit.max.version>
+        <jackrabbit.max.version>2.22.1</jackrabbit.max.version>
         <!-- for dependencies used for calculating OSGi import-package version ranges the minimally supported version should be used to be backwards compatible in OSGi containers -->
         <oak.min.version>1.22.4</oak.min.version>
         <!-- for embedded dependencies the newest version should be used -->
-        <oak.max.version>1.72.0</oak.max.version>
+        <oak.max.version>1.82.0</oak.max.version>
         <slf4j.version>1.7.25</slf4j.version>
         <commons-io.version>2.7</commons-io.version>
         <test.oak>true</test.oak> <!-- passed to integration test as property "oak", set to true to test with Oak, false means test with Jackrabbit 2 -->

--- a/target-osgi-environment/max-target-osgi-environment/pom.xml
+++ b/target-osgi-environment/max-target-osgi-environment/pom.xml
@@ -34,8 +34,6 @@
     <description>The bndrun files referencing a repository index (containing all bundles with their metadata) for resolving all FileVault bundles with dependent bundles in their maximum supported version</description>
 
     <properties>
-        <jackrabbit.version>2.20.10</jackrabbit.version>
-        <oak.version>1.52.0</oak.version>
         <jackson.version>2.13.4</jackson.version>
     </properties>
 
@@ -161,25 +159,25 @@
         <dependency>
             <groupId>org.apache.jackrabbit</groupId>
             <artifactId>oak-jackrabbit-api</artifactId>
-            <version>${oak.version}</version>
+            <version>${oak.max.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.jackrabbit</groupId>
             <artifactId>jackrabbit-webdav</artifactId>
-            <version>${jackrabbit.version}</version>
+            <version>${jackrabbit.max.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.jackrabbit</groupId>
             <artifactId>jackrabbit-jcr-commons</artifactId>
-            <version>${jackrabbit.version}</version>
+            <version>${jackrabbit.max.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.jackrabbit</groupId>
             <artifactId>jackrabbit-spi-commons</artifactId>
-            <version>${jackrabbit.version}</version>
+            <version>${jackrabbit.max.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/target-osgi-environment/min-target-osgi-environment/pom.xml
+++ b/target-osgi-environment/min-target-osgi-environment/pom.xml
@@ -35,8 +35,6 @@
     <description>The bndrun files referencing a repository index (containing all bundles with their metadata) for resolving all FileVault bundles with dependent bundles in their minimally required version</description>
 
     <properties>
-        <jackrabbit.version>2.20.8</jackrabbit.version>
-        <oak.version>1.22.14</oak.version>
         <jackson.version>2.13.4</jackson.version>
     </properties>
 
@@ -162,25 +160,25 @@
         <dependency>
             <groupId>org.apache.jackrabbit</groupId>
             <artifactId>oak-jackrabbit-api</artifactId>
-            <version>${oak.version}</version>
+            <version>${oak.min.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.jackrabbit</groupId>
             <artifactId>jackrabbit-webdav</artifactId>
-            <version>${jackrabbit.version}</version>
+            <version>${jackrabbit.min.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.jackrabbit</groupId>
             <artifactId>jackrabbit-jcr-commons</artifactId>
-            <version>${jackrabbit.version}</version>
+            <version>${jackrabbit.min.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.jackrabbit</groupId>
             <artifactId>jackrabbit-spi-commons</artifactId>
-            <version>${jackrabbit.version}</version>
+            <version>${jackrabbit.min.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/vault-validation/pom.xml
+++ b/vault-validation/pom.xml
@@ -159,6 +159,12 @@
         </dependency>
 
         <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
             <!-- see JCRVLT-680 -->
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-collections4</artifactId>


### PR DESCRIPTION
Test against newest Oak 1.82.0 and JR2 2.22.1
Minimum OSGi runtime dependencies remain unchanged