### PR TITLE
Fail build when dependency-check finds dependencies with CVSS 4 or

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -273,7 +273,8 @@ Bundle-Category: jackrabbit
                                 <goal>check</goal>
                             </goals>
                             <configuration>
-                                <failBuildOnCVSS>11</failBuildOnCVSS>
+                                <!-- fail for CVSS above LOW (https://nvd.nist.gov/vuln-metrics/cvss) -->
+                                <failBuildOnCVSS>4</failBuildOnCVSS>
                                 <!-- use the mirror provided by https://github.com/dependency-check/DependencyCheck_Builder which is updated daily -->
                                 <!-- compare with https://jeremylong.github.io/DependencyCheck/data/mirrornvd.html -->
                                 <nvdDatafeedUrl>https://dependency-check.github.io/DependencyCheck_Builder/nvd_cache/</nvdDatafeedUrl>

--- a/vault-cli/pom.xml
+++ b/vault-cli/pom.xml
@@ -39,7 +39,7 @@
 
     <properties>
         <!-- embed the newest JR2 versions -->
-        <jackrabbit.min.version>2.20.16</jackrabbit.min.version>
+        <jackrabbit.min.version>${jackrabbit.max.version}</jackrabbit.min.version>
     </properties>
     <!-- ====================================================================== -->
     <!-- B U I L D   D E F I N I T I O N                                        -->
@@ -187,6 +187,12 @@
                 <artifactId>httpclient</artifactId>
                 <version>4.5.14</version>
             </dependency>
+            <!-- minimum SLF4J API supported by non vulnerable logback 1.5-->
+            <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>slf4j-api</artifactId>
+                <version>2.0.17</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 
@@ -262,7 +268,7 @@
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>1.2.10</version>
+            <version>1.5.18</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>

--- a/vault-rcp/pom.xml
+++ b/vault-rcp/pom.xml
@@ -50,13 +50,16 @@
                     <artifactId>dependency-check-maven</artifactId>
                     <configuration>
                         <suppressionFile>${project.basedir}/../suppressions.xml</suppressionFile>
-                        <!-- only check embedded dependencies, therefore exclude all external dependencies with vulnerabilities (provided by the container) -->
+                        <!-- only check embedded dependencies, therefore exclude all external dependencies (provided by the container) -->
                         <excludes>
                             <exclude>*:commons-io</exclude>
                             <exclude>*:httpclient</exclude>
                             <exclude>*:jackson-core</exclude>
                             <exclude>*:jackson-databind</exclude>
                             <exclude>*:org.apache.sling.api</exclude>
+                            <exclude>org.apache.jackrabbit</exclude>
+                            <exclude>org.apache.jackrabbit.vault</exclude>
+                            <exclude>org.osgi</exclude>
                         </excludes>
                     </configuration>
                 </plugin>

--- a/vault-sync/pom.xml
+++ b/vault-sync/pom.xml
@@ -52,10 +52,13 @@
                     <artifactId>dependency-check-maven</artifactId>
                     <configuration>
                         <suppressionFile>${project.basedir}/../suppressions.xml</suppressionFile>
-                        <!-- only check embedded dependencies, therefore exclude all external dependencies with vulnerabilities (provided by the container) -->
+                        <!-- only check embedded dependencies, therefore exclude all external dependencies (provided by the container) -->
                         <excludes>
                             <exclude>*:commons-io</exclude>
                             <exclude>*:guava</exclude>
+                            <exclude>org.apache.jackrabbit</exclude>
+                            <exclude>org.apache.jackrabbit.vault</exclude>
+                            <exclude>org.osgi</exclude>
                         </excludes>
                     </configuration>
                 </plugin>

--- a/vault-validation/pom.xml
+++ b/vault-validation/pom.xml
@@ -62,6 +62,8 @@
                             <exclude>*:commons-io</exclude>
                             <exclude>*:httpclient</exclude>
                             <exclude>*:guava</exclude>
+                            <exclude>org.apache.commons</exclude>
+                            <exclude>org.apache.johnzon</exclude>
                         </excludes>
                     </configuration>
                 </plugin>


### PR DESCRIPTION
higher

This is severity MEDIUM or above
(https://nvd.nist.gov/vuln-metrics/cvss)