### PR TITLE
Suppress build failure for CVE-2025-58782

### DIFF
--- a/suppressions.xml
+++ b/suppressions.xml
@@ -78,4 +78,11 @@
        <packageUrl regex="true">^pkg:maven/org\.codehaus\.plexus/plexus\-utils@.*$</packageUrl>
        <cve>CVE-2021-4277</cve>
     </suppress>
+    <suppress>
+       <notes><![CDATA[
+       file name: jackrabbit-jcr-commons-2.20.17.jar with JNDI usage, not used in FileVault
+       ]]></notes>
+       <packageUrl regex="true">^pkg:maven/org\.apache\.jackrabbit/jackrabbit-jcr-commons@.*$</packageUrl>
+       <vulnerabilityName>CVE-2025-58782</vulnerabilityName>
+    </suppress>
 </suppressions>


### PR DESCRIPTION
FileVault is not affected as it doesn't use JNDI