### PR TITLE
JCRVLT-831: For collection of namespace prefixes, avoid iterating over sibling nodes not contained in the filter(s)

### DIFF
--- a/vault-core/src/main/java/org/apache/jackrabbit/vault/fs/impl/AggregateImpl.java
+++ b/vault-core/src/main/java/org/apache/jackrabbit/vault/fs/impl/AggregateImpl.java
@@ -645,12 +645,18 @@ public class AggregateImpl implements Aggregate {
                 addNamespace(prefixes, p);
             }
         }
-        for (NodeIterator iter = node.getNodes(); iter.hasNext(); ) {
+        boolean hasOrderableChildNodes = node.getPrimaryNodeType().hasOrderableChildNodes();
+        // use the node iterator optimized for the workspace filter if and only if the node is not orderable,
+        // in which case we still need to visit all sibling nodes, as their prefixes wil be needed in the
+        // serialization (as empty nodes)
+        NodeIterator iter =
+                hasOrderableChildNodes ? node.getNodes() : getNodeIteratorFor(node, mgr.getWorkspaceFilter());
+        while (iter.hasNext()) {
             Node c = iter.nextNode();
             String relPath = parentPath + "/" + c.getName();
             if (includes(relPath)) {
                 loadNamespaces(prefixes, relPath, c);
-            } else if (node.getPrimaryNodeType().hasOrderableChildNodes()) {
+            } else if (hasOrderableChildNodes) {
                 addNamespace(prefixes, c.getName());
             }
         }

--- a/vault-core/src/main/java/org/apache/jackrabbit/vault/fs/impl/AggregateImpl.java
+++ b/vault-core/src/main/java/org/apache/jackrabbit/vault/fs/impl/AggregateImpl.java
@@ -647,7 +647,7 @@ public class AggregateImpl implements Aggregate {
         }
         boolean hasOrderableChildNodes = node.getPrimaryNodeType().hasOrderableChildNodes();
         // use the node iterator optimized for the workspace filter if and only if the node is not orderable,
-        // in which case we still need to visit all sibling nodes, as their prefixes wil be needed in the
+        // in which case we still need to visit all sibling nodes, as their prefixes will be needed in the
         // serialization (as empty nodes)
         NodeIterator iter =
                 hasOrderableChildNodes ? node.getNodes() : getNodeIteratorFor(node, mgr.getWorkspaceFilter());


### PR DESCRIPTION
...if not in an orderable collection in which case the prefixes are still needed.