### PR TITLE
Remove transitive unused Maven dependencies

### DIFF
--- a/vault-validation/pom.xml
+++ b/vault-validation/pom.xml
@@ -95,6 +95,12 @@
       <artifactId>maven-artifact</artifactId>
       <version>3.8.4</version>
       <scope>provided</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
Those suffer from vulnerabilities which otherwise lead to false positives with dependency-checker.