### PR TITLE
JCRVLT-847 Move spotless execution to "verify" phase

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -361,7 +361,7 @@ Apache Jackrabbit FileVault is a project of the Apache Software Foundation.</des
               <goals>
                 <goal>${spotless.action}</goal>
               </goals>
-              <phase>process-sources</phase>
+              <phase>verify</phase>
             </execution>
           </executions>
         </plugin>


### PR DESCRIPTION
This minimizes interruption of ongoing work in the IDE and with the CLI as one can easily leave that phase out (if not desired).