### PR TITLE
Add missed release notes for 4.0.0

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -17,20 +17,20 @@ Release Notes - Jackrabbit FileVault - Version 4.2.0
 This version requires Java 11 or above
 The OSGi bundles depend on Jackrabbit 2.20.17+ (JCR Commons, SPI, SPI Commons), Oak JR API 1.22.4+, Commons IO 2.18+, Commons Collections 4.1+ and SLF4J 1.7+
 
-** Improvement
-    * [JCRVLT-782] - Introduce spotless-maven-plugin
-    * [JCRVLT-825] - Remove Patch Support (extracting files from packages to filesystem)
-    * [JCRVLT-831] - For collection of namespace prefixes, avoid iterating over sibling nodes not contained in the filter(s)
-    * [JCRVLT-832] - No test coverage for handling namespace information in PATH typed property values
-    * [JCRVLT-839] - Unconditional child node iteration in AggregateImpl.walk()
+Improvement
+    [JCRVLT-782] - Introduce spotless-maven-plugin
+    [JCRVLT-825] - Remove Patch Support (extracting files from packages to filesystem)
+    [JCRVLT-831] - For collection of namespace prefixes, avoid iterating over sibling nodes not contained in the filter(s)
+    [JCRVLT-832] - No test coverage for handling namespace information in PATH typed property values
+    [JCRVLT-839] - Unconditional child node iteration in AggregateImpl.walk()
 
-** Test
-    * [JCRVLT-834] - add test coverage for namespace prefixes on sibling nodes in ordered collections
+Test
+    [JCRVLT-834] - add test coverage for namespace prefixes on sibling nodes in ordered collections
 
 
-** Task
-    * [JCRVLT-823] - add .DS_Store to .gitignore
-    * [JCRVLT-836] - log durations and number of nodes in AggregateImpl node walk
+Task
+    [JCRVLT-823] - add .DS_Store to .gitignore
+    [JCRVLT-836] - log durations and number of nodes in AggregateImpl node walk
 
 
 Changes in Jackrabbit FileVault 4.1.4
@@ -40,16 +40,16 @@ Release Notes - Jackrabbit FileVault - Version 4.1.4
 This version requires Java 11 or above
 The OSGi bundles depend on Jackrabbit 2.20.17+ (JCR Commons, SPI, SPI Commons), Oak JR API 1.22.4+, Commons IO 2.18+, Commons Collections 4.1+ and SLF4J 1.7+
 
-** Improvement
-    * [JCRVLT-816] - Fix Security warnings
-    * [JCRVLT-817] - All properties are checked twice if they are protected
-    * [JCRVLT-818] - Vault CLI contains embedded vulnerable libraries
-    * [JCRVLT-819] - Upgrade JLine 1.0 to 3.x
-    * [JCRVLT-822] - avoid costly check if a property is protected
+Improvement
+    [JCRVLT-816] - Fix Security warnings
+    [JCRVLT-817] - All properties are checked twice if they are protected
+    [JCRVLT-818] - Vault CLI contains embedded vulnerable libraries
+    [JCRVLT-819] - Upgrade JLine 1.0 to 3.x
+    [JCRVLT-822] - avoid costly check if a property is protected
 
-** Task
-    * [JCRVLT-813] - read node and property definitions lazy
-    * [JCRVLT-814] - Remove redundant calculations in DocViewImporer
+Task
+    [JCRVLT-813] - read node and property definitions lazy
+    [JCRVLT-814] - Remove redundant calculations in DocViewImporer
 
 
 Changes in Jackrabbit FileVault 4.1.2
@@ -69,7 +69,7 @@ This version requires Java 11 or above
 The OSGi bundles depend on Jackrabbit 2.20.17+ (JCR Commons, SPI, SPI Commons), Oak JR API 1.22.4+, Commons IO 2.7+, Commons Collections 4.1+ and SLF4J 1.7+
 
 Bug
-
+    [JCRVLT-800] - Version command is broken
     [JCRVLT-807] - PackageProperties.getDateProperty() should not log exception on log level
 
 Improvement
@@ -77,6 +77,8 @@ Improvement
     [JCRVLT-748] - Fix XSD namespaces
     [JCRVLT-764] - Require Java 11 
     [JCRVLT-790] - Upgrade embedded Jackrabbit/Oak version to 2.22.1/1.82.0
+    [JCRVLT-801] - jackrabbit-packagetype validator should detect conflicting filter rules
+    [JCRVLT-801] - Update ASF Parent to version 24
     [JCRVLT-805] - DocViewImporter: remove redundant name calculation
     [JCRVLT-808] - Improve multi-module code coverage
     [JCRVLT-809] - DocViewImporter: logIgnoredProtectedProperties can slow down package import


### PR DESCRIPTION
Some have incorrectly been targeted for the skipped version 3.8.6.

Fix formatting